### PR TITLE
Fix thumbnail hover zoom overflow

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -113,24 +113,43 @@ jqu129-codex/polish-thumbnail-styling-and-spacing
 
 .media-thumbs__btn {
   box-sizing: border-box;
-  overflow: visible; /* Prevent clipping when scaled */
+  padding: 0;
   border: 1px solid #d9d9d9;
   border-radius: 6px;
   background-color: var(--gallery-bg-color);
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s, border-color 0.2s;
+  transition: box-shadow 0.2s, border-color 0.2s;
 }
 /* Remove underline and use subtle shadow on hover */
 .media-thumbs__btn::after {
   display: none;
 }
 .media-thumbs__btn:hover {
-  /* Enlarge slightly on hover */
+  /* Subtle shadow on hover */
   box-shadow: 0 0 0 1px rgba(var(--text-color), 0.3), 0 1px 3px rgba(0, 0, 0, 0.1);
-  transform: scale(1.05);
 }
 .media-thumbs__btn.is-active {
   border-color: #000;
   box-shadow: none;
+}
+
+.media-thumb__image-wrapper {
+  display: block;
+  line-height: 0;
+  overflow: hidden;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.media-thumb__image-wrapper img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.2s ease;
+}
+
+.media-thumbs__btn:hover .media-thumb__image-wrapper img,
+.media-thumbs__btn:focus .media-thumb__image-wrapper img {
+  transform: scale(1.05);
 }
 
 .media-thumbs__badge {

--- a/snippets/gallery-zoom.liquid
+++ b/snippets/gallery-zoom.liquid
@@ -45,14 +45,16 @@
                           endif
                         -%}
 
-                        {% render 'image',
-                          image: media,
-                          src_width: src_width,
-                          srcset_2x: true,
-                          lazy_load: false,
-                          class: img_class,
-                          disable_focal_point: true
-                        %}
+                        <div class="media-thumb__image-wrapper">
+                          {% render 'image',
+                            image: media,
+                            src_width: src_width,
+                            srcset_2x: true,
+                            lazy_load: false,
+                            class: img_class,
+                            disable_focal_point: true
+                          %}
+                        </div>
                       </button>
                     </li>
                   {%- endfor -%}

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -280,14 +280,16 @@
                   endif
                 -%}
 
-                {% render 'image',
-                  image: media,
-                  src_width: src_width,
-                  srcset_2x: true,
-                  lazy_load: false,
-                  class: img_class,
-                  disable_focal_point: true
-                %}
+                <div class="media-thumb__image-wrapper">
+                  {% render 'image',
+                    image: media,
+                    src_width: src_width,
+                    srcset_2x: true,
+                    lazy_load: false,
+                    class: img_class,
+                    disable_focal_point: true
+                  %}
+                </div>
               </button>
             </li>
           {%- endfor -%}


### PR DESCRIPTION
## Summary
- keep thumbnail zoom inside borders
- add wrapper element around product thumbnails
- apply transform scaling to `<img>` only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880c11479f88326bf50ba6fb1e01d54