### PR TITLE
Refactor product page gallery to vertical hover preview

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -37,6 +37,10 @@
 .media-gallery__viewer {
   border: 1px solid var(--gallery-border-color);
   background-color: var(--gallery-bg-color);
+  transition: opacity 0.2s ease;
+}
+.media-gallery__viewer.is-switching {
+  opacity: 0;
 }
 
 .media-viewer,
@@ -91,11 +95,7 @@
 }
 
 .media-gallery__thumbs {
-jqu129-codex/polish-thumbnail-styling-and-spacing
-  /* Position thumbnails slightly lower under the main image */
   margin-top: calc(1.5 * var(--space-unit) + 3px);
-
- main
 }
 
 /* Center thumbnails horizontally under the main image */
@@ -116,6 +116,7 @@ jqu129-codex/polish-thumbnail-styling-and-spacing
   padding: 0;
   border: 1px solid #d9d9d9;
   border-radius: 6px;
+  overflow: hidden;
   background-color: var(--gallery-bg-color);
   transition: box-shadow 0.2s, border-color 0.2s;
 }
@@ -347,5 +348,48 @@ product-model[loaded] .media-poster {
   }
   .product-media--stacked .media-viewer__item:not(.media-viewer__item--single) {
     flex: 0 0 50%;
+  }
+}
+
+@media (min-width: 769px) {
+  .product-media__inner {
+    display: flex;
+    align-items: center;
+  }
+  .product-media__inner .media-gallery {
+    display: flex;
+  }
+  .product-media__inner .media-gallery__thumbs {
+    width: 80px;
+    margin-right: 12px;
+  }
+  .product-media__inner .media-gallery__viewer {
+    flex: 1;
+  }
+  .product-media__inner .media-thumbs {
+    flex-direction: column;
+    align-items: center;
+  }
+  .product-media__inner .media-thumbs__item:not(:last-child) {
+    margin-inline-end: 0;
+    margin-bottom: 12px;
+  }
+}
+
+@media (max-width: 768.98px) {
+  .product-media__inner .media-gallery {
+    display: block;
+  }
+  .product-media__inner .media-gallery__thumbs {
+    width: 100%;
+    margin-right: 0;
+    margin-top: var(--media-gap);
+  }
+  .product-media__inner .media-thumbs {
+    flex-direction: row;
+  }
+  .product-media__inner .media-thumbs__item:not(:last-child) {
+    margin-inline-end: var(--media-gap);
+    margin-bottom: 0;
   }
 }

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -279,7 +279,12 @@ if (!customElements.get('media-gallery')) {
     addListeners() {
       this.viewer.addEventListener('scroll', this.handleScroll.bind(this));
       if (this.controls) this.controls.addEventListener('click', this.handleNavClick.bind(this));
-      if (this.thumbs) this.thumbs.addEventListener('click', this.handleThumbClick.bind(this));
+      if (this.thumbs) {
+        this.thumbs.addEventListener('click', this.handleThumbClick.bind(this));
+        if (window.matchMedia('(hover: hover)').matches) {
+          this.thumbs.addEventListener('mouseover', this.handleThumbHover.bind(this));
+        }
+      }
       this.resizeHandler = this.resizeHandler || this.handleResize.bind(this);
       window.addEventListener('on:debounced-resize', this.resizeHandler);
     }
@@ -372,15 +377,25 @@ if (!customElements.get('media-gallery')) {
      * Handles 'click' events on the thumbnails container.
      * @param {object} evt - Event object.
      */
-    handleThumbClick(evt) {
-      const thumb = evt.target.closest('[data-media-id]');
-      if (!thumb) return;
+  handleThumbClick(evt) {
+    const thumb = evt.target.closest('[data-media-id]');
+    if (!thumb) return;
 
-      const itemToShow = this.querySelector(`[data-media-id="${thumb.dataset.mediaId}"]`);
-      this.customSetActiveMedia(itemToShow);
+    const itemToShow = this.querySelector(`[data-media-id="${thumb.dataset.mediaId}"]`);
+    this.customSetActiveMedia(itemToShow);
 
-      MediaGallery.playActiveMedia(itemToShow);
-    }
+    MediaGallery.playActiveMedia(itemToShow);
+  }
+
+  handleThumbHover(evt) {
+    const thumb = evt.target.closest('[data-media-id]');
+    if (!thumb) return;
+    const btn = thumb.querySelector('button');
+    if (btn && btn.classList.contains('is-active')) return;
+    const itemToShow = this.querySelector(`[data-media-id="${thumb.dataset.mediaId}"]`);
+    this.customSetActiveMedia(itemToShow);
+    MediaGallery.playActiveMedia(itemToShow);
+  }
 
     /**
      * Handles debounced 'resize' events on the window.
@@ -408,6 +423,7 @@ if (!customElements.get('media-gallery')) {
     customSetActiveMedia(mediaItem, scrollToItem = true) {
       if (mediaItem === this.currentItem) return;
       window.pauseAllMedia(this);
+      this.viewer.classList.add('is-switching');
       this.currentItem = mediaItem;
       this.currentIndex = this.visibleItems.indexOf(this.currentItem);
 
@@ -435,6 +451,9 @@ if (!customElements.get('media-gallery')) {
       }
 
       if (scrollToItem) this.viewer.scrollTo({ left: this.currentItem.offsetLeft });
+      requestAnimationFrame(() => {
+        this.viewer.classList.remove('is-switching');
+      });
       if (this.thumbs) this.setActiveThumb();
 
       if (this.controls) {

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -15,7 +15,7 @@
 @media (min-width: 769px) {
   :root {
     /* Horizontal space between gallery and info (~40px) */
-    --product-column-padding: calc(6 * var(--space-unit));
+    --product-column-padding: calc(6.25 * var(--space-unit));
     /* Wider info column for modern layout */
     --product-info-width: 56%;
   }
@@ -110,7 +110,7 @@
 @media (min-width: 1280px) {
   :root {
     /* Reduce extra-wide padding further */
-    --product-column-padding: calc(6 * var(--space-unit));
+    --product-column-padding: calc(6.25 * var(--space-unit));
   }
   .product-main .product-media,
   .product-main .product-info {


### PR DESCRIPTION
## Summary
- fade main gallery image when switching
- support thumbnail hover switching
- add overflow style for thumbnails
- layout thumbs vertically beside main image on desktop
- tweak column padding to about 40px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880c59bd9e88326860d6b1879bb8fb4