### PR TITLE
Fix product image layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -354,17 +354,22 @@ product-model[loaded] .media-poster {
 @media (min-width: 769px) {
   .product-media__inner {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    gap: 32px;
   }
   .product-media__inner .media-gallery {
     display: flex;
   }
   .product-media__inner .media-gallery__thumbs {
     width: 80px;
-    margin-right: 12px;
+    flex: 0 0 auto;
+    margin-right: 0;
   }
   .product-media__inner .media-gallery__viewer {
     flex: 1;
+    max-width: 550px;
+    width: 100%;
+    box-sizing: border-box;
   }
   .product-media__inner .media-thumbs {
     flex-direction: column;
@@ -377,6 +382,9 @@ product-model[loaded] .media-poster {
 }
 
 @media (max-width: 768.98px) {
+  .product-media__inner {
+    display: block;
+  }
   .product-media__inner .media-gallery {
     display: block;
   }
@@ -384,6 +392,9 @@ product-model[loaded] .media-poster {
     width: 100%;
     margin-right: 0;
     margin-top: var(--media-gap);
+  }
+  .product-media__inner .media-gallery__viewer {
+    max-width: 100%;
   }
   .product-media__inner .media-thumbs {
     flex-direction: row;

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -15,7 +15,7 @@
 @media (min-width: 769px) {
   :root {
     /* Horizontal space between gallery and info (~40px) */
-    --product-column-padding: calc(6.25 * var(--space-unit));
+    --product-column-padding: calc(8 * var(--space-unit));
     /* Wider info column for modern layout */
     --product-info-width: 56%;
   }
@@ -58,8 +58,8 @@
       padding-top: calc(6 * var(--space-unit));
       padding-bottom: calc(6 * var(--space-unit));
       padding-inline-end: var(--product-column-padding);
-      /* Limit width so images don't overwhelm the layout */
-      max-width: 620px;
+        /* Limit width so images don't overwhelm the layout */
+        max-width: 550px;
     }
     /* Sticky image gallery when there is room */
     .product-media__inner {
@@ -110,7 +110,7 @@
 @media (min-width: 1280px) {
   :root {
     /* Reduce extra-wide padding further */
-    --product-column-padding: calc(6.25 * var(--space-unit));
+    --product-column-padding: calc(8 * var(--space-unit));
   }
   .product-main .product-media,
   .product-main .product-info {

--- a/assets/product.css
+++ b/assets/product.css
@@ -385,6 +385,19 @@ quantity-input + .product-info__add-button {
   margin-bottom: 0;
 }
 
+/* Harmonize main product image sizing */
+.media-gallery__viewer {
+  box-sizing: border-box;
+  max-width: 550px;
+  width: 100%;
+}
+
+.media-gallery__viewer img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
 .tab-used .product-info__block .media {
   overflow: visible;
 }


### PR DESCRIPTION
## Summary
- prevent main product image from shifting by using a fixed flex layout
- limit main image width for consistent sizing
- adjust spacing between gallery and info sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880c87410a88326afa64beb73d53c3d