### PR TITLE
Fix product gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -367,6 +367,7 @@ product-model[loaded] .media-poster {
   }
   .product-media__inner .media-gallery {
     display: flex;
+    flex-direction: row-reverse;
   }
   .product-media__inner .media-gallery__thumbs {
     width: 80px;
@@ -374,7 +375,7 @@ product-model[loaded] .media-poster {
   }
   .product-media__inner .media-gallery__viewer {
     flex: 1;
-    max-width: 550px;
+    max-width: 650px;
     width: 100%;
   }
   .product-media__inner .media-thumbs {

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -59,7 +59,7 @@
       padding-bottom: calc(6 * var(--space-unit));
       padding-inline-end: var(--product-column-padding);
       /* Limit width so images don't overwhelm the layout */
-      max-width: 550px;
+      max-width: 650px;
     }
     /* Sticky image gallery when there is room */
     .product-media__inner {

--- a/assets/product.css
+++ b/assets/product.css
@@ -388,7 +388,7 @@ quantity-input + .product-info__add-button {
 /* Harmonize main product image sizing */
 .media-gallery__viewer {
   box-sizing: border-box;
-  max-width: 550px;
+  max-width: 650px;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- move main product image to the right of thumbnails by reversing the flex layout
- enlarge gallery viewer for a more professional product page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880cc84f9848326b0633a6651833531