### PR TITLE
Fix main product image size

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1892,3 +1892,15 @@ if (window.OverlayScrollbarsGlobal) {
   initMobileScrollbars();
   document.addEventListener('shopify:section:load', initMobileScrollbars);
 }
+
+// Ensure product image sizing overrides inline aspect ratios
+document.addEventListener('DOMContentLoaded', () => {
+  const mainImage = document.querySelector('.media-gallery__viewer img.product-image');
+  if (mainImage) {
+    mainImage.style.aspectRatio = 'unset';
+    mainImage.style.width = '100%';
+    mainImage.style.height = 'auto';
+    mainImage.style.maxHeight = '600px';
+    mainImage.style.objectFit = 'contain';
+  }
+}, { once: true });

--- a/assets/product.css
+++ b/assets/product.css
@@ -388,15 +388,20 @@ quantity-input + .product-info__add-button {
 /* Harmonize main product image sizing */
 .media-gallery__viewer {
   box-sizing: border-box;
+  max-width: 550px;
   width: 100%;
-  max-width: none;
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .media-gallery__viewer img {
   width: 100%;
   height: auto;
+  aspect-ratio: unset !important;
   object-fit: contain;
-  aspect-ratio: auto;
+  max-height: 600px;
 }
 
 .tab-used .product-info__block .media {


### PR DESCRIPTION
## Summary
- update `product.css` to control `.media-gallery__viewer` width and override aspect ratio
- add JS fallback to reset inline aspect ratio on the product image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880d29591e88326be65530c28da1521