### PR TITLE
Fix main product image sizing

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1895,12 +1895,14 @@ if (window.OverlayScrollbarsGlobal) {
 
 // Ensure product image sizing overrides inline aspect ratios
 document.addEventListener('DOMContentLoaded', () => {
-  const mainImage = document.querySelector('.media-gallery__viewer img.product-image');
-  if (mainImage) {
-    mainImage.style.aspectRatio = 'unset';
-    mainImage.style.width = '100%';
-    mainImage.style.height = 'auto';
-    mainImage.style.maxHeight = '600px';
-    mainImage.style.objectFit = 'contain';
+  const image = document.querySelector('.product-image.img-fit');
+  if (image) {
+    image.removeAttribute('width');
+    image.removeAttribute('height');
+    image.style.width = '100%';
+    image.style.height = 'auto';
+    image.style.aspectRatio = 'unset';
+    image.style.maxWidth = '550px';
+    image.style.objectFit = 'contain';
   }
 }, { once: true });

--- a/assets/product.css
+++ b/assets/product.css
@@ -388,7 +388,7 @@ quantity-input + .product-info__add-button {
 /* Harmonize main product image sizing */
 .media-gallery__viewer {
   box-sizing: border-box;
-  max-width: 550px;
+  max-width: 600px;
   width: 100%;
   height: auto;
   display: flex;
@@ -402,6 +402,14 @@ quantity-input + .product-info__add-button {
   aspect-ratio: unset !important;
   object-fit: contain;
   max-height: 600px;
+}
+
+.product-image.img-fit {
+  width: 100%;
+  height: auto;
+  aspect-ratio: unset !important;
+  object-fit: contain;
+  max-width: 550px;
 }
 
 .tab-used .product-info__block .media {

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -29,6 +29,10 @@
 {%- endcomment -%}
 
 {%- liquid
+  assign omit_dimensions = false
+  if class and class contains 'product-image'
+    assign omit_dimensions = true
+  endif
   if srcset_2x
     assign image_width = src_width
     assign src_width_2x = src_width | times: 2
@@ -143,10 +147,9 @@
 {%- if image and src_width -%}
   {%- if mobile_srcset -%}
     <picture>
-      <source srcset="{{ mobile_srcset }}"
-              media="(max-width: 600px)"
-              width="{{ mobile_image_width }}"
-              height="{{ mobile_image_width | divided_by: image.aspect_ratio | round }}">
+        <source srcset="{{ mobile_srcset }}"
+                media="(max-width: 600px)"
+                {% unless omit_dimensions %}width="{{ mobile_image_width }}" height="{{ mobile_image_width | divided_by: image.aspect_ratio | round }}"{% endunless %}>
   {%- endif -%}
 
   {%- if as_mobile_source -%}
@@ -157,8 +160,7 @@
          {% if attributes %}{{ attributes }} {% endif -%}
          {% if disable_focal_point == false and image.presentation %}style="object-position: {{ image.presentation.focal_point }}" {% endif -%}
          loading="{% if lazy_load %}lazy{% else %}eager{% endif %}"
-         width="{{ image_width }}"
-         height="{{ image_height }}"
+         {% unless omit_dimensions %}width="{{ image_width }}" height="{{ image_height }}"{% endunless %}
          alt="{{ alt_text | default: image.alt | escape }}"
          media="(max-width: 767px)">
   {%- else -%}
@@ -169,8 +171,7 @@
          {% if attributes %}{{ attributes }} {% endif -%}
          {% if disable_focal_point == false and image.presentation %}style="object-position: {{ image.presentation.focal_point }}" {% endif -%}
          loading="{% if lazy_load %}lazy{% else %}eager{% endif %}"
-         width="{{ image_width }}"
-         height="{{ image_height }}"
+         {% unless omit_dimensions %}width="{{ image_width }}" height="{{ image_height }}"{% endunless %}
          {% if fetchpriority %}fetchpriority="{{ fetchpriority }}"{% endif %}
          alt="{{ alt_text | default: image.alt | escape }}">
   {%- endif -%}


### PR DESCRIPTION
## Summary
- allow enough space for product image viewer
- add `.product-image.img-fit` CSS to reset width/height
- drop width/height attributes on product images in `image` snippet
- force-correct styles in JS if any inline width/height remain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880d57c3c54832693d3c10c474738bd