### PR TITLE
Fix main product image dimensions

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1893,14 +1893,16 @@ if (window.OverlayScrollbarsGlobal) {
   document.addEventListener('shopify:section:load', initMobileScrollbars);
 }
 
-// Ensure product image sizing overrides inline aspect ratios
+// Ensure product image sizing overrides inline dimensions
 document.addEventListener('DOMContentLoaded', () => {
-  const mainImage = document.querySelector('.media-gallery__viewer img.product-image');
-  if (mainImage) {
-    mainImage.style.aspectRatio = 'unset';
-    mainImage.style.width = '100%';
-    mainImage.style.height = 'auto';
-    mainImage.style.maxHeight = '600px';
-    mainImage.style.objectFit = 'contain';
+  const image = document.querySelector('.product-image.img-fit');
+  if (image) {
+    image.removeAttribute('width');
+    image.removeAttribute('height');
+    image.style.width = '100%';
+    image.style.height = 'auto';
+    image.style.aspectRatio = 'unset';
+    image.style.maxWidth = '550px';
+    image.style.objectFit = 'contain';
   }
 }, { once: true });

--- a/assets/product.css
+++ b/assets/product.css
@@ -2,6 +2,7 @@
   padding: 0;
   border: 0;
 }
+
 .option-selector:not(:last-child) {
   margin-bottom: 2rem;
 }
@@ -460,4 +461,12 @@ quantity-input + .product-info__add-button {
   .product-details .disclosure__content {
     padding-bottom: calc(8 * var(--space-unit));
   }
+}
+
+.product-image.img-fit {
+  width: 100%;
+  height: auto;
+  aspect-ratio: unset !important;
+  object-fit: contain;
+  max-width: 550px;
 }

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -17,6 +17,7 @@
   - disable_focal_point {Boolean} - Disables the focussing of a spot on the image (optional, default is false).
   - section_index {Number} - If passed, image lazy load will be prevented if it's the first section
   - as_mobile_source {Boolean} - Will output <source> instead of <img> for use in <picture> (optional, default is false)
+  - skip_dimensions {Boolean} - Omits width and height attributes on the output element (optional, default is false)
 
   Usage:
   {% render 'image',
@@ -138,6 +139,7 @@
   endif
 
   assign disable_focal_point = disable_focal_point | default: false
+  assign skip_dimensions = skip_dimensions | default: false
 -%}
 
 {%- if image and src_width -%}
@@ -145,8 +147,7 @@
     <picture>
       <source srcset="{{ mobile_srcset }}"
               media="(max-width: 600px)"
-              width="{{ mobile_image_width }}"
-              height="{{ mobile_image_width | divided_by: image.aspect_ratio | round }}">
+              {% unless skip_dimensions %}width="{{ mobile_image_width }}" height="{{ mobile_image_width | divided_by: image.aspect_ratio | round }}"{% endunless %}>
   {%- endif -%}
 
   {%- if as_mobile_source -%}
@@ -157,8 +158,8 @@
          {% if attributes %}{{ attributes }} {% endif -%}
          {% if disable_focal_point == false and image.presentation %}style="object-position: {{ image.presentation.focal_point }}" {% endif -%}
          loading="{% if lazy_load %}lazy{% else %}eager{% endif %}"
-         width="{{ image_width }}"
-         height="{{ image_height }}"
+         {% unless skip_dimensions %}width="{{ image_width }}"{% endunless %}
+         {% unless skip_dimensions %}height="{{ image_height }}"{% endunless %}
          alt="{{ alt_text | default: image.alt | escape }}"
          media="(max-width: 767px)">
   {%- else -%}
@@ -169,8 +170,8 @@
          {% if attributes %}{{ attributes }} {% endif -%}
          {% if disable_focal_point == false and image.presentation %}style="object-position: {{ image.presentation.focal_point }}" {% endif -%}
          loading="{% if lazy_load %}lazy{% else %}eager{% endif %}"
-         width="{{ image_width }}"
-         height="{{ image_height }}"
+         {% unless skip_dimensions %}width="{{ image_width }}"{% endunless %}
+         {% unless skip_dimensions %}height="{{ image_height }}"{% endunless %}
          {% if fetchpriority %}fetchpriority="{{ fetchpriority }}"{% endif %}
          alt="{{ alt_text | default: image.alt | escape }}">
   {%- endif -%}

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -138,7 +138,8 @@
       sizes: sizes,
       lazy_load: lazy_load,
       class: img_class,
-      disable_focal_point: true
+      disable_focal_point: true,
+      skip_dimensions: true
     %}
 
     {%- if enable_zoom -%}
@@ -181,7 +182,8 @@
       lazy_load: lazy_load,
       class: img_class,
       alt_text: media.alt,
-      disable_focal_point: true
+      disable_focal_point: true,
+      skip_dimensions: true
     %}
   </button>
 


### PR DESCRIPTION
## Summary
- allow `image` snippet to skip width/height attributes
- render product media images without fixed dimensions
- force product image dimensions via CSS
- adjust JS to clean attributes at runtime

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880d57c3c54832693d3c10c474738bd