### PR TITLE
feat: add frequently bought section and service icons

### DIFF
--- a/assets/product.css
+++ b/assets/product.css
@@ -436,3 +436,43 @@ quantity-input + .product-info__add-button {
     padding-bottom: calc(8 * var(--space-unit));
   }
 }
+
+.product-services {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.product-services .service-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.fbt {
+  margin-top: 4rem;
+  padding: 2rem;
+  background: #fff;
+  border: 1px solid rgba(var(--text-color)/0.1);
+}
+
+.fbt__products {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.fbt__product {
+  text-align: center;
+}
+
+.fbt__operator {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.fbt__total-price {
+  font-size: 1.25rem;
+}

--- a/sections/frequently-bought-together.liquid
+++ b/sections/frequently-bought-together.liquid
@@ -1,0 +1,39 @@
+{% assign prod1 = all_products[section.settings.product_1] %}
+{% assign prod2 = all_products[section.settings.product_2] %}
+<section class="fbt">
+  {% if prod1 and prod2 %}
+    <div class="fbt__products">
+      <div class="fbt__product">
+        <a href="{{ prod1.url }}">
+          <img src="{{ prod1.featured_image | image_url }}" alt="{{ prod1.title }}" width="200" height="200" loading="lazy">
+          <p>{{ prod1.title }}</p>
+          <p>{{ prod1.price | money }}</p>
+        </a>
+      </div>
+      <div class="fbt__operator">+</div>
+      <div class="fbt__product">
+        <a href="{{ prod2.url }}">
+          <img src="{{ prod2.featured_image | image_url }}" alt="{{ prod2.title }}" width="200" height="200" loading="lazy">
+          <p>{{ prod2.title }}</p>
+          <p>{{ prod2.price | money }}</p>
+        </a>
+      </div>
+      <div class="fbt__operator">=</div>
+      <div class="fbt__total text-center">
+        {% assign total = prod1.price | plus: prod2.price %}
+        <p class="fbt__total-price font-bold">{{ total | money }}</p>
+        <button class="btn btn--primary mt-2">{{ 'products.product.add_to_cart' | t }}</button>
+      </div>
+    </div>
+  {% endif %}
+</section>
+
+{% schema %}
+{
+  "name": "Frequently Bought Together",
+  "settings": [
+    { "type": "product", "id": "product_1", "label": "Product 1" },
+    { "type": "product", "id": "product_2", "label": "Product 2" }
+  ]
+}
+{% endschema %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -121,7 +121,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
+    <div class="product-info card{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
          {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media,.cc-main-product + .cc-product-details .container"{% endif %}>
       {%- if section.settings.stick_on_scroll -%}
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
@@ -682,6 +682,8 @@
             {%- endif -%}
         {%- endcase -%}
       {%- endfor -%}
+
+      {% render 'service-icons' %}
 
       {%- if section.settings.stick_on_scroll -%}
         </div>

--- a/snippets/service-icons.liquid
+++ b/snippets/service-icons.liquid
@@ -1,0 +1,14 @@
+<div class="product-services flex gap-6 mt-6">
+  <div class="service-item flex items-center gap-2">
+    {% render 'icon', icon: 'box', width: 24, height: 24 %}
+    <span>Versandkostenfrei</span>
+  </div>
+  <div class="service-item flex items-center gap-2">
+    {% render 'icon', icon: 'award', width: 24, height: 24 %}
+    <span>2 Jahre Garantie</span>
+  </div>
+  <div class="service-item flex items-center gap-2">
+    {% render 'icon', icon: 'heart', width: 24, height: 24 %}
+    <span>Top Support</span>
+  </div>
+</div>

--- a/templates/product.json
+++ b/templates/product.json
@@ -154,14 +154,21 @@
         "media_grouping_option": "Color,Colour,Couleur,Farbe"
       }
     },
+    "fbt": {
+      "type": "frequently-bought-together",
+      "settings": {
+        "product_1": "",
+        "product_2": ""
+      }
+    },
     "details": {
       "type": "product-details",
       "blocks": {
         "tabs": {
           "type": "tabs",
           "settings": {
-            "style": "tabs",
-            "open_first": false,
+            "style": "collapsible",
+            "open_first": true,
             "show_description": true,
             "show_reviews": false,
             "custom_reviews": "",
@@ -219,6 +226,7 @@
   },
   "order": [
     "main",
+    "fbt",
     "details",
     "recommendations",
     "1743585275ab058f49"

--- a/tests/frequently_bought_together_test.rb
+++ b/tests/frequently_bought_together_test.rb
@@ -1,0 +1,30 @@
+require 'minitest/autorun'
+require 'liquid'
+
+module TestFilters
+  def money(input)
+    "$#{input}"
+  end
+  def image_url(input, **args)
+    input['src'] || input
+  end
+end
+Liquid::Template.register_filter(TestFilters)
+
+class FrequentlyBoughtTogetherTest < Minitest::Test
+  def test_render
+    content = File.read('sections/frequently-bought-together.liquid').split('{% schema %}').first
+    template = Liquid::Template.parse(content)
+    ctx = {
+      'section' => { 'settings' => { 'product_1' => 'a', 'product_2' => 'b' } },
+      'all_products' => {
+        'a' => { 'title' => 'Product A', 'price' => 1000, 'url' => '/a', 'featured_image' => { 'src' => 'a.jpg' } },
+        'b' => { 'title' => 'Product B', 'price' => 2000, 'url' => '/b', 'featured_image' => { 'src' => 'b.jpg' } }
+      }
+    }
+    output = template.render(ctx)
+    assert_includes output, 'Product A'
+    assert_includes output, 'Product B'
+    assert_includes output, '$3000'
+  end
+end

--- a/tests/run_tests.rb
+++ b/tests/run_tests.rb
@@ -1,0 +1,2 @@
+require_relative 'service_icons_test'
+require_relative 'frequently_bought_together_test'

--- a/tests/service_icons_test.rb
+++ b/tests/service_icons_test.rb
@@ -1,0 +1,10 @@
+require 'minitest/autorun'
+require 'liquid'
+
+class ServiceIconsTest < Minitest::Test
+  def test_render
+    template = Liquid::Template.parse(File.read('snippets/service-icons.liquid'))
+    output = template.render
+    assert_includes output, 'product-services'
+  end
+end


### PR DESCRIPTION
## Summary
- add card styling and service icons to product info
- introduce frequently bought together section and accordion product details
- cover new components with Liquid rendering tests

## Testing
- `ruby tests/run_tests.rb`
- `theme-check` *(fails: ImgWidthAndHeight, ImgLazyLoading, AssetPreload warnings remain in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6894523e77cc8326802d5e32f75aad65