### PR TITLE
Add Frequently Bought Together section and service icons

### DIFF
--- a/assets/fbt.css
+++ b/assets/fbt.css
@@ -1,0 +1,4 @@
+.fbt-section{background:#fff;padding:2rem 0}
+.fbt-items{display:flex;align-items:center;justify-content:center;gap:1rem;flex-wrap:wrap}
+.fbt-sign{font-size:2rem;font-weight:700}
+.fbt-summary{padding:1rem;border:1px solid #eee;border-radius:4px;text-align:center}

--- a/assets/product-service-icons.css
+++ b/assets/product-service-icons.css
@@ -1,0 +1,3 @@
+.service-icons{display:flex;gap:1rem;margin-top:1rem;flex-wrap:wrap}
+.service-icon{display:flex;align-items:center;gap:0.5rem;font-size:0.875rem}
+.service-icon svg{width:20px;height:20px}

--- a/sections/frequently-bought-together.liquid
+++ b/sections/frequently-bought-together.liquid
@@ -1,0 +1,45 @@
+{{ 'fbt.css' | asset_url | stylesheet_tag }}
+{%- liquid
+  assign p1 = all_products[section.settings.product_1]
+  assign p2 = all_products[section.settings.product_2]
+  assign total = 0
+  if p1 and p1.selected_or_first_available_variant
+    assign total = total | plus: p1.selected_or_first_available_variant.price
+  endif
+  if p2 and p2.selected_or_first_available_variant
+    assign total = total | plus: p2.selected_or_first_available_variant.price
+  endif
+-%}
+<div class="fbt-section container">
+  <h2 class="h3">Frequently Bought Together</h2>
+  <div class="fbt-items">
+    {% if p1 %}
+      <div class="fbt-item">{% render 'product-card', product: p1 %}</div>
+    {% endif %}
+    <div class="fbt-sign">+</div>
+    {% if p2 %}
+      <div class="fbt-item">{% render 'product-card', product: p2 %}</div>
+    {% endif %}
+    <div class="fbt-sign">=</div>
+    <div class="fbt-summary">
+      <div class="fbt-total">{{ total | money }}</div>
+      {% if p1 and p2 %}
+      <form method="post" action="/cart/add">
+        <input type="hidden" name="id[]" value="{{ p1.selected_or_first_available_variant.id }}">
+        <input type="hidden" name="id[]" value="{{ p2.selected_or_first_available_variant.id }}">
+        <button type="submit" class="btn btn--primary">Beide in den Warenkorb</button>
+      </form>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Frequently bought together",
+  "settings": [
+    {"type": "product", "id": "product_1", "label": "Product 1"},
+    {"type": "product", "id": "product_2", "label": "Product 2"}
+  ]
+}
+{% endschema %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2,6 +2,7 @@
 {%- comment -%}Build: bg-info-bg text-info-text{%- endcomment -%}
 {{ 'product.css' | asset_url | stylesheet_tag }}
 {{ 'product-page.css' | asset_url | stylesheet_tag }}
+{{ 'product-service-icons.css' | asset_url | stylesheet_tag }}
 
 
 
@@ -349,6 +350,7 @@
               {%- if block.settings.show_pickup_availability -%}
                 {% render 'pickup-availability', current_variant: current_variant %}
               {%- endif -%}
+              {% render 'service-icons' %}
             </div>
 
           {%- when 'complementary' -%}

--- a/snippets/service-icons.liquid
+++ b/snippets/service-icons.liquid
@@ -1,0 +1,14 @@
+<div class="service-icons">
+  <div class="service-icon">
+    {% render 'icon-available' %}
+    <span>Versand in 24h</span>
+  </div>
+  <div class="service-icon">
+    {% render 'icon-bag' %}
+    <span>Kostenloser Versand</span>
+  </div>
+  <div class="service-icon">
+    {% render 'icon-check' %}
+    <span>30 Tage Rückgabe</span>
+  </div>
+</div>

--- a/templates/product.json
+++ b/templates/product.json
@@ -154,6 +154,10 @@
         "media_grouping_option": "Color,Colour,Couleur,Farbe"
       }
     },
+    "fbt": {
+      "type": "frequently-bought-together",
+      "settings": {}
+    },
     "details": {
       "type": "product-details",
       "blocks": {
@@ -219,6 +223,7 @@
   },
   "order": [
     "main",
+    "fbt",
     "details",
     "recommendations",
     "1743585275ab058f49"


### PR DESCRIPTION
## Summary
- add new service icons snippet and styles to product page
- add Frequently Bought Together section with two selectable products and combined add to cart
- wire new section into product template order

## Testing
- `npx @shopify/theme-check@latest --init` *(fails: Not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894523e77cc8326802d5e32f75aad65