### PR TITLE
Refactor product page layout with recommendations

### DIFF
--- a/assets/product-fbt.js
+++ b/assets/product-fbt.js
@@ -1,0 +1,10 @@
+document.addEventListener('click', (e) => {
+  if (e.target.matches('.fbt-add')) {
+    const ids = e.target.dataset.products.split(',').map(id => ({ id: parseInt(id, 10), quantity: 1 }));
+    fetch('/cart/add.js', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: ids })
+    }).then(() => { window.location.href = '/cart'; });
+  }
+});

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -123,7 +123,93 @@
     --product-column-padding: calc(12 * var(--space-unit));
   }
   .product-main .product-media,
-  .product-main .product-info {
+.product-main .product-info {
     padding-top: calc(12 * var(--space-unit));
   }
+}
+
+.product {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+@media (min-width: 768px) {
+  .product {
+    flex-direction: row;
+  }
+  .product-media { width: 60%; }
+  .product-info { width: 40%; }
+}
+.product-media .media-gallery__thumbs {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+.product-info-card {
+  background: #fff;
+  padding: 2rem;
+  border: 1px solid #eee;
+  border-radius: 0.5rem;
+}
+.product-bullets {
+  margin: 1rem 0;
+  padding-left: 1.25rem;
+}
+.product-bullets li {
+  list-style: disc;
+  margin-bottom: 0.25rem;
+}
+.variant-thumbnails {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+.variant-thumb {
+  border: 1px solid #ddd;
+  padding: 2px;
+  border-radius: 4px;
+}
+.variant-thumb input {
+  display: none;
+}
+.variant-thumb img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+}
+.service-icons {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.service-icon {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+.fbt-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 3rem;
+}
+.fbt-symbol {
+  font-size: 2rem;
+  line-height: 1;
+}
+.fbt-total {
+  text-align: center;
+}
+.product-accordion details {
+  border-top: 1px solid #eee;
+  padding: 1rem 0;
+}
+.product-accordion summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+.product-accordion__content {
+  margin-top: 0.5rem;
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -127,6 +127,9 @@
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
       <sticky-scroll-direction data-min-sticky-size="md">
         <div class="product-info__sticky">
+          <div class="product-info-card">
+      {%- else -%}
+        <div class="product-info-card">
       {%- endif -%}
 
       {%- assign has_variant_picker = false -%}
@@ -684,10 +687,25 @@
       {%- endfor -%}
 
       {%- if section.settings.stick_on_scroll -%}
+          {% render 'product-bullets', product: product %}
+          {% render 'variant-thumbnails', product: product, product_form_id: product_form_id %}
+          {% render 'service-icons' %}
+        </div>
         </div>
       </sticky-scroll-direction>
+      {%- else -%}
+          {% render 'product-bullets', product: product %}
+          {% render 'variant-thumbnails', product: product, product_form_id: product_form_id %}
+          {% render 'service-icons' %}
+        </div>
       {%- endif -%}
     </div>
+  </div>
+  <div class="product-fbt-section">
+    {% render 'product-fbt', product: product %}
+  </div>
+  <div class="product-accordion-section">
+    {% render 'product-accordion', product: product %}
   </div>
 </div>
 

--- a/snippets/product-accordion.liquid
+++ b/snippets/product-accordion.liquid
@@ -1,0 +1,16 @@
+<div class="product-accordion">
+  <details open>
+    <summary>Beschreibung</summary>
+    <div class="product-accordion__content">
+      {{ product.description }}
+    </div>
+  </details>
+  {% if product.metafields.custom.manufacturer %}
+  <details>
+    <summary>Herstellerinformation</summary>
+    <div class="product-accordion__content">
+      {{ product.metafields.custom.manufacturer }}
+    </div>
+  </details>
+  {% endif %}
+</div>

--- a/snippets/product-bullets.liquid
+++ b/snippets/product-bullets.liquid
@@ -1,0 +1,8 @@
+{%- assign bullets = product.metafields.custom.bullet_points | newline_to_br | strip_newlines | split: '<br />' -%}
+{%- if bullets.size > 0 and bullets[0] != '' -%}
+<ul class="product-bullets">
+  {%- for bullet in bullets -%}
+  <li>{{ bullet }}</li>
+  {%- endfor -%}
+</ul>
+{%- endif -%}

--- a/snippets/product-fbt.liquid
+++ b/snippets/product-fbt.liquid
@@ -1,0 +1,19 @@
+{% assign recs = recommendations.products | slice: 0,1 %}
+{% if recs.size > 0 %}
+<div class="fbt-wrapper">
+  <div class="fbt-item">
+    {% render 'product-card', product: product %}
+  </div>
+  <span class="fbt-symbol">+</span>
+  <div class="fbt-item">
+    {% render 'product-card', product: recs[0] %}
+  </div>
+  <span class="fbt-symbol">=</span>
+  <div class="fbt-total">
+    {% assign total_price = product.price | plus: recs[0].price %}
+    <div class="fbt-total-price">{{ total_price | money }}</div>
+    <button type="button" class="btn fbt-add" data-products="{{ product.id }},{{ recs[0].id }}">Add all to cart</button>
+  </div>
+</div>
+<script src="{{ 'product-fbt.js' | asset_url }}" defer></script>
+{% endif %}

--- a/snippets/service-icons.liquid
+++ b/snippets/service-icons.liquid
@@ -1,0 +1,10 @@
+<div class="service-icons">
+  <div class="service-icon">
+    <span class="service-icon__emoji">🚚</span>
+    <span>Fast Shipping</span>
+  </div>
+  <div class="service-icon">
+    <span class="service-icon__emoji">🔒</span>
+    <span>Secure Checkout</span>
+  </div>
+</div>

--- a/snippets/variant-thumbnails.liquid
+++ b/snippets/variant-thumbnails.liquid
@@ -1,0 +1,12 @@
+{%- if product.variants.size > 1 -%}
+<div class="variant-thumbnails">
+  {%- for variant in product.variants -%}
+    {%- if variant.featured_image -%}
+    <label class="variant-thumb">
+      <input type="radio" name="id" value="{{ variant.id }}" form="{{ product_form_id }}" {% if variant == product.selected_or_first_available_variant %}checked{% endif %}>
+      <img src="{{ variant.featured_image | img_url: '100x100' }}" alt="{{ variant.title | escape }}" width="100" height="100" loading="lazy">
+    </label>
+    {%- endif -%}
+  {%- endfor -%}
+</div>
+{%- endif -%}


### PR DESCRIPTION
## Summary
- style product pages with card layout, gallery thumbnails and service icons
- add frequently-bought-together block and accordion product details
- include variant thumbnail picker and supporting scripts/styles

## Testing
- `theme-check`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894523e77cc8326802d5e32f75aad65