### PR TITLE
Add product gallery and info card section

### DIFF
--- a/assets/product-top.css
+++ b/assets/product-top.css
@@ -1,0 +1,168 @@
+.product-top {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.product-top__gallery,
+.product-top__info {
+  flex: 1 1 500px;
+}
+.product-gallery {
+  text-align: center;
+}
+.product-gallery__image-wrapper {
+  position: relative;
+  max-width: 500px;
+  margin: 0 auto;
+}
+.product-gallery__image {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+.product-gallery__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: #bbb;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.product-gallery__nav:hover {
+  background: #ffa726;
+}
+.product-gallery__nav--prev {
+  left: -20px;
+}
+.product-gallery__nav--next {
+  right: -20px;
+}
+.product-gallery__thumbs {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+.product-gallery__thumb {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.product-gallery__thumb--active {
+  border-color: #ffa726;
+}
+.product-info-card {
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  padding: 1.5rem;
+}
+.product-info-card__title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #222;
+  margin: 0 0 1rem;
+}
+.product-info-card__rating {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.product-info-card__stars {
+  display: flex;
+}
+.product-info-card__rating-text {
+  margin-left: 0.5rem;
+  color: #222;
+}
+.product-info-card__features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+.product-info-card__feature {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+.product-info-card__feature-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.5rem;
+  fill: none;
+}
+.product-info-card__price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #222;
+  margin-bottom: 0.5rem;
+}
+.product-info-card__availability {
+  color: #43a047;
+  margin-bottom: 1rem;
+}
+.product-info-card__variants {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.product-info-card__variant {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.product-info-card__variant--active {
+  border-color: #ffa726;
+}
+.product-info-card__add {
+  width: 100%;
+  background: #ffa726;
+  color: #222;
+  border: none;
+  padding: 1rem;
+  border-radius: 4px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.product-info-card__services {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.product-info-card__service {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #222;
+}
+.product-info-card__service-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.25rem;
+  fill: none;
+}
+@media (max-width: 768px) {
+  .product-top {
+    flex-direction: column;
+  }
+  .product-gallery__nav--prev {
+    left: 10px;
+  }
+  .product-gallery__nav--next {
+    right: 10px;
+  }
+}

--- a/sections/product-top.liquid
+++ b/sections/product-top.liquid
@@ -1,0 +1,173 @@
+{% comment %}
+  Product top section: gallery and info card
+{% endcomment %}
+
+{{ 'product-top.css' | asset_url | stylesheet_tag }}
+
+<section class="product-top" id="product-top-{{ section.id }}">
+  <div class="product-top__gallery">
+    <div id="ProductGallery-{{ section.id }}" class="product-gallery">
+      <div class="product-gallery__image-wrapper">
+        <button type="button" class="product-gallery__nav product-gallery__nav--prev" aria-label="Zurück">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+        </button>
+        {% assign first_image = product.images.first %}
+        <img src="{{ first_image | image_url: width: 500, height: 500 }}" width="500" height="500" loading="eager" alt="{{ product.title }}" class="product-gallery__image" id="MainImage-{{ section.id }}">
+        <button type="button" class="product-gallery__nav product-gallery__nav--next" aria-label="Weiter">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+        </button>
+      </div>
+      <div class="product-gallery__thumbs">
+        {% for image in product.images %}
+          <img src="{{ image | image_url: width: 60, height: 60 }}" width="60" height="60" loading="lazy" data-image="{{ image | image_url: width: 500, height: 500 }}" alt="{{ product.title }}" class="product-gallery__thumb">
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+  <div class="product-top__info">
+    <div class="product-info-card">
+      <h1 class="product-info-card__title">{{ product.title }}</h1>
+      <div class="product-info-card__rating">
+        <div class="product-info-card__stars">
+          {% for i in (1..5) %}
+            <svg width="16" height="16" viewBox="0 0 24 24" class="product-info-card__star"><path fill="#ffa726" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>
+          {% endfor %}
+        </div>
+        <span class="product-info-card__rating-text">{{ section.settings.rating_text }}</span>
+      </div>
+      {% assign features = section.settings.features | newline_to_br | split: '<br />' %}
+      <ul class="product-info-card__features">
+        {% for feature in features %}
+          {% if feature != blank %}
+            <li class="product-info-card__feature">
+              <svg class="product-info-card__feature-icon" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" stroke="#bbb" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span>{{ feature }}</span>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+      <div class="product-info-card__price">{{ product.price | money }}</div>
+      <div class="product-info-card__availability">{{ section.settings.availability_text }}</div>
+      <div class="product-info-card__variants">
+        {% for variant in product.variants %}
+          {% if variant.featured_image %}
+            <img src="{{ variant.featured_image | image_url: width: 60, height: 60 }}" width="60" height="60" loading="lazy" alt="{{ variant.title }}" class="product-info-card__variant" data-variant-id="{{ variant.id }}" data-image="{{ variant.featured_image | image_url: width: 500, height: 500 }}">
+          {% endif %}
+        {% endfor %}
+      </div>
+      <form method="post" action="/cart/add" id="product-form-{{ section.id }}" class="product-info-card__form">
+        <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+        <button type="submit" class="product-info-card__add">{{ 'products.product.add_to_cart' | t }}</button>
+      </form>
+      <div class="product-info-card__services">
+        {% if section.settings.service_1 != blank %}
+          <div class="product-info-card__service">
+            <svg class="product-info-card__service-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="#bbb" stroke-width="2" fill="none"/></svg>
+            <span>{{ section.settings.service_1 }}</span>
+          </div>
+        {% endif %}
+        {% if section.settings.service_2 != blank %}
+          <div class="product-info-card__service">
+            <svg class="product-info-card__service-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="#bbb" stroke-width="2" fill="none"/></svg>
+            <span>{{ section.settings.service_2 }}</span>
+          </div>
+        {% endif %}
+        {% if section.settings.service_3 != blank %}
+          <div class="product-info-card__service">
+            <svg class="product-info-card__service-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="#bbb" stroke-width="2" fill="none"/></svg>
+            <span>{{ section.settings.service_3 }}</span>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const gallery = document.getElementById('ProductGallery-{{ section.id }}');
+    if (!gallery) return;
+    const mainImage = document.getElementById('MainImage-{{ section.id }}');
+    const thumbs = gallery.querySelectorAll('.product-gallery__thumb');
+    let index = 0;
+    function showImage(i){
+      const img = thumbs[i];
+      thumbs.forEach(t => t.classList.remove('product-gallery__thumb--active'));
+      img.classList.add('product-gallery__thumb--active');
+      mainImage.src = img.dataset.image;
+      index = i;
+    }
+    thumbs.forEach((thumb, i) => {
+      thumb.addEventListener('click', () => showImage(i));
+    });
+    const prev = gallery.querySelector('.product-gallery__nav--prev');
+    const next = gallery.querySelector('.product-gallery__nav--next');
+    prev.addEventListener('click', () => {
+      showImage((index - 1 + thumbs.length) % thumbs.length);
+    });
+    next.addEventListener('click', () => {
+      showImage((index + 1) % thumbs.length);
+    });
+    showImage(0);
+
+    const variantInput = document.querySelector('#product-form-{{ section.id }} input[name="id"]');
+    document.querySelectorAll('#product-top-{{ section.id }} .product-info-card__variant').forEach(v => {
+      v.addEventListener('click', () => {
+        document.querySelectorAll('#product-top-{{ section.id }} .product-info-card__variant').forEach(el => el.classList.remove('product-info-card__variant--active'));
+        v.classList.add('product-info-card__variant--active');
+        variantInput.value = v.dataset.variantId;
+        if (v.dataset.image) {
+          mainImage.src = v.dataset.image;
+        }
+      });
+    });
+  });
+</script>
+
+{% schema %}
+{
+  "name": "Product top",
+  "settings": [
+    {
+      "type": "textarea",
+      "id": "features",
+      "label": "Bullet features",
+      "default": "Feature 1\nFeature 2\nFeature 3"
+    },
+    {
+      "type": "text",
+      "id": "rating_text",
+      "label": "Rating text",
+      "default": "4.8/5"
+    },
+    {
+      "type": "text",
+      "id": "availability_text",
+      "label": "Availability text",
+      "default": "Verfügbar – Lieferung in 5–7 Werktagen"
+    },
+    {
+      "type": "text",
+      "id": "service_1",
+      "label": "Service text 1",
+      "default": "Schneller Versand"
+    },
+    {
+      "type": "text",
+      "id": "service_2",
+      "label": "Service text 2",
+      "default": "30 Tage Rückgabe"
+    },
+    {
+      "type": "text",
+      "id": "service_3",
+      "label": "Service text 3",
+      "default": "Sichere Zahlung"
+    }
+  ]
+}
+{% endschema %}
+
+{% stylesheet %}
+/* Inline fallback if asset missing */
+{% endstylesheet %}

--- a/templates/product.top.json
+++ b/templates/product.top.json
@@ -1,0 +1,11 @@
+{
+  "sections": {
+    "main": {
+      "type": "product-top",
+      "settings": {}
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- create `product-top` section with image gallery and info card (title, rating, features, variants, CTA)
- add `product-top.css` for responsive BEM layout
- wire new section through `product.top.json` template

## Testing
- `theme-check > /tmp/theme.log && grep 'product-top.liquid' /tmp/theme.log` *(no output)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689457fbdf288326891ec2c53a997024