### PR TITLE
Fix missing variant ID in add-to-cart

### DIFF
--- a/assets/variant-picker.js
+++ b/assets/variant-picker.js
@@ -29,6 +29,7 @@ if (!customElements.get('variant-picker')) {
       setTimeout(() => {
         this.updateAvailability();
         this.updateAddToCartButton();
+        if (this.variant) this.updateVariantInput();
       });
     }
 
@@ -405,6 +406,8 @@ if (!customElements.get('variant-picker')) {
 
       this.forms.forEach((form) => {
         const input = form.querySelector('input[name="id"]');
+        input.disabled = false;
+        input.removeAttribute('disabled');
         input.value = this.variant.id;
         input.dispatchEvent(new Event('change', { bubbles: true }));
       });


### PR DESCRIPTION
## Summary
- ensure variant ID input is enabled and updated so add-to-cart succeeds

## Testing
- `npx @shopify/theme-check@latest` *(fails: package not found)*
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689478ec238483268470f9823dd033cc