### PR TITLE
feat: add product info card styling

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -127,3 +127,26 @@
     padding-top: calc(12 * var(--space-unit));
   }
 }
+
+body.template-product {
+  background-color: #f7f7f7;
+}
+
+.product-info-card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 24px rgba(30,38,94,0.09);
+  padding: 28px;
+}
+
+.product-info-card .product-info__block,
+.product-info-card .product-info__block--sm,
+.product-info-card .product-details__block {
+  margin: 0 0 22px !important;
+}
+
+.product-info-card .product-info__block:last-child,
+.product-info-card .product-info__block--sm:last-child,
+.product-info-card .product-details__block:last-child {
+  margin-bottom: 0 !important;
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -120,7 +120,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
+    <div class="product-info product-info-card{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
          {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media,.cc-main-product + .cc-product-details .container"{% endif %}>
       {%- if section.settings.stick_on_scroll -%}
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>


### PR DESCRIPTION
## Summary
- style product info section as a white card with shadow and rounded corners
- unify spacing between product detail blocks
- apply light gray background to product page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx theme-check` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68947bd66e548326a53879d03e4fb621