### PR TITLE
feat: add product info card styling

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -127,3 +127,55 @@
     padding-top: calc(12 * var(--space-unit));
   }
 }
+
+body.template-product {
+  background-color: #f7f7f7;
+}
+
+.product-info-card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 24px rgba(30,38,94,0.09);
+  padding: 28px;
+  text-align: center;
+}
+
+.product-info-card .product-info__block,
+.product-info-card .product-info__block--sm,
+.product-info-card .product-details__block {
+  margin: 0 0 22px !important;
+}
+
+.product-info-card .product-info__block:last-child,
+.product-info-card .product-info__block--sm:last-child,
+.product-info-card .product-details__block:last-child {
+  margin-bottom: 0 !important;
+}
+
+.product-info-card .product-info__add-to-cart {
+  flex-direction: column;
+  align-items: center;
+}
+
+.product-info-card .product-info__add-to-cart quantity-input {
+  flex: 0 0 auto;
+  margin-inline-end: 0;
+  margin-bottom: calc(2 * var(--space-unit));
+  width: 100%;
+}
+
+.product-info-card .product-info__add-button {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+.product-info-card .product-info__add-button .btn {
+  width: auto;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.product-info-card .service-icons,
+.product-info-card .icons-with-text {
+  justify-content: center;
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -120,7 +120,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
+    <div class="product-info product-info-card{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
          {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media,.cc-main-product + .cc-product-details .container"{% endif %}>
       {%- if section.settings.stick_on_scroll -%}
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
@@ -325,7 +325,7 @@
                         {%- endif -%}
                       {%- endcapture -%}
 
-                      <button type="submit" data-add-to-cart-text="{{ add_to_cart_text | escape }}" class="btn {% if enable_dynamic_checkout %}btn--secondary{% else %}btn--primary{% endif %} w-full" name="add"{% if product.available == false or section.settings.select_first_variant == false and product.variants.size > 1 %} disabled{% endif %}>
+                      <button type="submit" data-add-to-cart-text="{{ add_to_cart_text | escape }}" class="btn {% if enable_dynamic_checkout %}btn--secondary{% else %}btn--primary{% endif %}" name="add"{% if product.available == false or section.settings.select_first_variant == false and product.variants.size > 1 %} disabled{% endif %}>
                         {% if section.settings.select_first_variant == false and product.variants.size > 1 -%}
                           {{ "products.variant.not_selected" | t }}
                         {%- elsif product.available -%}


### PR DESCRIPTION
## Summary
- style product info section as a white card with shadow and rounded corners
- unify spacing between product detail blocks
- apply light gray background to product page
- center all content inside the product info card including add-to-cart button and service icons

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx theme-check` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68947bd66e548326a53879d03e4fb621