### PR TITLE
Style product info card for consistent spacing

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -127,3 +127,25 @@
     padding-top: calc(12 * var(--space-unit));
   }
 }
+
+.product-main .product-info {
+  background-color: transparent;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.product-info-card {
+  text-align: left;
+  padding: 32px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.product-info-card > .product-info__block {
+  margin: 0 0 22px;
+}
+
+.product-info-card > .product-info__block:last-child {
+  margin-bottom: 0;
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -133,6 +133,7 @@
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
       {%- endif -%}
 
+      <div class="product-info-card">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when '@app' -%}
@@ -681,6 +682,7 @@
             {%- endif -%}
         {%- endcase -%}
       {%- endfor -%}
+      </div>
 
       {%- if section.settings.stick_on_scroll -%}
         </div>


### PR DESCRIPTION
## Summary
- wrap product info blocks in a `.product-info-card` container for unified layout
- add card styling with uniform padding, margins, and subtle radius/shadow
- clear parent background and extra padding so card stands out

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ShopifyTheme_Malte/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894858fe0308326beb69c7972051d0f