### PR TITLE
feat: make product media sticky and remove divider

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -29,10 +29,6 @@
   .product-breadcrumbs + .product-main .product-info {
     padding-top: 0;
   }
-  .product-breadcrumbs + .product-main .product-info::before,
-  .product-breadcrumbs + .product-main .product-info::after {
-    top: calc(-10 * var(--space-unit) - 1em - 2px);
-  }
   .shopify-section + .product-main {
     margin-top: -1px;
   }
@@ -52,7 +48,6 @@
     width: calc(100% - var(--product-info-width));
     float: left;
     clear: left;
-    border-inline-end: 1px solid rgba(var(--text-color)/0.15);
   }
   .product-main .product-media {
     margin-top: 0;
@@ -68,18 +63,6 @@
     padding-inline-start: var(--product-column-padding);
     float: right;
     background-color: rgba(var(--bg-color));
-  }
-  .product-main .product-info::before, .product-main .product-info::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: -2px;
-    left: -1px;
-    width: 1px;
-    background-color: rgba(var(--bg-color));
-  }
-  .product-main .product-info::after {
-    background-color: rgba(var(--text-color)/0.15);
   }
   .product-main .product-info--sticky {
     min-height: var(--sticky-height, 0);
@@ -113,10 +96,6 @@
   [dir=rtl] .product-main .product-info {
     float: left;
   }
-  [dir=rtl] .product-main .product-info::before, [dir=rtl] .product-main .product-info::after {
-    right: -1px;
-    left: auto;
-  }
 }
 @media (min-width: 1280px) {
   :root {
@@ -125,6 +104,13 @@
   .product-main .product-media,
   .product-main .product-info {
     padding-top: calc(12 * var(--space-unit));
+  }
+}
+
+@media (min-width: 1024px) {
+  .product-main .product-media {
+    position: sticky;
+    top: var(--header-end-padded, 70px);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove vertical divider between product gallery and details panel
- keep product gallery sticky on desktop for better visibility

## Testing
- `npm test` (fails: ENOENT package.json)
- `theme-check` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_6894949cf8808326a51c950a2c60c5a3