### PR TITLE
Refactor product tabs into offcanvas

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -135,3 +135,70 @@
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
 }
+.product-info-tabs__buttons {
+  display: flex;
+  flex-direction: column;
+  margin-top: calc(4 * var(--space-unit));
+}
+.product-info-tabs__button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: calc(2 * var(--space-unit)) 0;
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  background: none;
+}
+.product-info-tabs__button:first-child {
+  border-top: 1px solid rgba(0,0,0,0.08);
+}
+.product-info-tabs__button:hover,
+.product-info-tabs__button:focus {
+  background-color: rgba(0,0,0,0.04);
+}
+.product-info-tabs [data-offcanvas-overlay] {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .3s ease;
+  z-index: 90;
+}
+.product-info-tabs [data-offcanvas-overlay].is-active {
+  opacity: 1;
+  visibility: visible;
+}
+.product-offcanvas {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 100%;
+  max-width: 500px;
+  background: #fff;
+  transform: translateX(100%);
+  transition: transform .3s ease;
+  box-shadow: -2px 0 16px rgba(0,0,0,0.15);
+  padding: calc(4 * var(--space-unit));
+  overflow-y: auto;
+  z-index: 100;
+}
+.product-offcanvas.is-active {
+  transform: translateX(0);
+}
+.product-offcanvas__close {
+  position: absolute;
+  top: calc(2 * var(--space-unit));
+  right: calc(2 * var(--space-unit));
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+body.offcanvas-open {
+  overflow: hidden;
+}
+@media (min-width: 769px) {
+  .product-info-tabs__button {
+    padding: calc(3 * var(--space-unit)) 0;
+  }
+}

--- a/assets/product-tabs.js
+++ b/assets/product-tabs.js
@@ -1,0 +1,45 @@
+class ProductTabsOffcanvas {
+  constructor(container) {
+    this.container = container;
+    this.overlay = container.querySelector('[data-offcanvas-overlay]');
+    this.buttons = container.querySelectorAll('[data-offcanvas-target]');
+    this.panels = container.querySelectorAll('.product-offcanvas');
+    this.closeButtons = container.querySelectorAll('[data-offcanvas-close]');
+    this.activePanel = null;
+    this.addEvents();
+  }
+  addEvents() {
+    this.buttons.forEach((btn) => {
+      btn.addEventListener('click', () => this.open(btn.dataset.offcanvasTarget));
+    });
+    this.closeButtons.forEach((btn) => btn.addEventListener('click', () => this.close()));
+    if (this.overlay) {
+      this.overlay.addEventListener('click', () => this.close());
+    }
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        this.close();
+      }
+    });
+  }
+  open(id) {
+    const panel = this.container.querySelector(`#offcanvas-${id}`);
+    if (!panel) return;
+    this.activePanel = panel;
+    panel.classList.add('is-active');
+    if (this.overlay) this.overlay.classList.add('is-active');
+    document.body.classList.add('offcanvas-open');
+  }
+  close() {
+    if (this.activePanel) {
+      this.activePanel.classList.remove('is-active');
+      this.activePanel = null;
+    }
+    if (this.overlay) this.overlay.classList.remove('is-active');
+    document.body.classList.remove('offcanvas-open');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.product-info-tabs').forEach((el) => new ProductTabsOffcanvas(el));
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -631,6 +631,47 @@
               <script src="{{ 'variant-label.js' | asset_url }}" defer="defer"></script>
             {%- endif -%}
 
+          {%- when 'tabs' -%}
+            <div class="product-info__block product-info-tabs" {{ block.shopify_attributes }}>
+              <div class="product-info-tabs__buttons">
+                <button type="button" class="product-info-tabs__button" data-offcanvas-target="description">
+                  {{ 'products.product.description' | t }}
+                </button>
+                {%- if block.settings.tab_1_title != blank -%}
+                  <button type="button" class="product-info-tabs__button" data-offcanvas-target="tab1">
+                    {{ block.settings.tab_1_title }}
+                  </button>
+                {%- endif -%}
+              </div>
+
+              <div class="product-info-tabs__overlay" data-offcanvas-overlay></div>
+
+              <div class="product-offcanvas" id="offcanvas-description" tabindex="-1" aria-hidden="true">
+                <button class="product-offcanvas__close" type="button" data-offcanvas-close>
+                  {% render 'icon-close' %}
+                </button>
+                <h2 class="h5">{{ 'products.product.description' | t }}</h2>
+                <div class="product-offcanvas__content rte">
+                  {{ product.description }}
+                </div>
+              </div>
+
+              {%- if block.settings.tab_1_title != blank -%}
+                <div class="product-offcanvas" id="offcanvas-tab1" tabindex="-1" aria-hidden="true">
+                  <button class="product-offcanvas__close" type="button" data-offcanvas-close>
+                    {% render 'icon-close' %}
+                  </button>
+                  <h2 class="h5">{{ block.settings.tab_1_title }}</h2>
+                  <div class="product-offcanvas__content rte">
+                    {{ block.settings.tab_1_text }}
+                    {{ block.settings.tab_1_page.content }}
+                  </div>
+                </div>
+              {%- endif -%}
+
+              <script src="{{ 'product-tabs.js' | asset_url }}" defer></script>
+            </div>
+
           {% when 'custom-option' %}
             {%- if block.settings.label != blank -%}
               {%- liquid
@@ -2383,6 +2424,30 @@
           "label": "Options",
           "default": "Option 1\nOption 2\nOption 3",
           "info": "One option on each line"
+        }
+      ]
+    }
+    ,
+    {
+      "type": "tabs",
+      "name": "Info tabs",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "text",
+          "id": "tab_1_title",
+          "label": "Tab 1 title",
+          "default": "Herstellerinformationen"
+        },
+        {
+          "type": "richtext",
+          "id": "tab_1_text",
+          "label": "Tab 1 content"
+        },
+        {
+          "type": "page",
+          "id": "tab_1_page",
+          "label": "Tab 1 page"
         }
       ]
     }

--- a/templates/product.json
+++ b/templates/product.json
@@ -84,6 +84,30 @@
             "products_to_show": 4,
             "layout": "list"
           }
+        },
+        "tabs": {
+          "type": "tabs",
+          "settings": {
+            "style": "tabs",
+            "open_first": false,
+            "show_description": true,
+            "show_reviews": false,
+            "custom_reviews": "",
+            "show_specification": false,
+            "spec_metafields": "Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten",
+            "spec_right_align": false,
+            "spec_show_empty_metafields": false,
+            "spec_empty_field_text": "-",
+            "tab_1_title": "Herstellerinformationen",
+            "tab_1_text": "<p><strong>Herstellerinformationen: </strong></p><p>{{ product.metafields.custom.herstellerinformationen | metafield_tag }}</p><p><strong>Importeur: </strong></p><p>{{ product.metafields.custom.importeur | metafield_tag }}</p><p><strong>EU-Verantwortliche Person:</strong></p><p>{{ product.metafields.custom.eu_verantwortliche_person | metafield_tag }}</p><p></p>",
+            "tab_1_page": "",
+            "tab_2_title": "",
+            "tab_2_text": "",
+            "tab_2_page": "",
+            "tab_3_title": "",
+            "tab_3_text": "",
+            "tab_3_page": ""
+          }
         }
       },
       "block_order": [
@@ -96,7 +120,8 @@
         "buy-buttons",
         "custom_liquid_kKPgLF",
         "product-labels",
-        "complementary_rx84bf"
+        "complementary_rx84bf",
+        "tabs"
       ],
       "custom_css": [
         "h1 {font-weight: 700; font-size: 3.2rem; letter-spacing: -0.02em; color: #181c32; margin-top: 20px; margin-right: 40px; /* optional für Abstand nach unten */ line-height: 1.15;}"
@@ -130,40 +155,6 @@
         "media_grouping_option": "Color,Colour,Couleur,Farbe"
       }
     },
-    "details": {
-      "type": "product-details",
-      "blocks": {
-        "tabs": {
-          "type": "tabs",
-          "settings": {
-            "style": "tabs",
-            "open_first": false,
-            "show_description": true,
-            "show_reviews": false,
-            "custom_reviews": "",
-            "show_specification": false,
-            "spec_metafields": "Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten",
-            "spec_right_align": false,
-            "spec_show_empty_metafields": false,
-            "spec_empty_field_text": "-",
-            "tab_1_title": "Herstellerinformationen",
-            "tab_1_text": "<p><strong>Herstellerinformationen: </strong></p><p>{{ product.metafields.custom.herstellerinformationen | metafield_tag }}</p><p><strong>Importeur: </strong></p><p>{{ product.metafields.custom.importeur | metafield_tag }}</p><p><strong>EU-Verantwortliche Person:</strong></p><p>{{ product.metafields.custom.eu_verantwortliche_person | metafield_tag }}</p><p></p>",
-            "tab_1_page": "",
-            "tab_2_title": "",
-            "tab_2_text": "",
-            "tab_2_page": "",
-            "tab_3_title": "",
-            "tab_3_text": "",
-            "tab_3_page": ""
-          }
-        }
-      },
-      "block_order": [
-        "tabs"
-      ],
-      "custom_css": [],
-      "settings": {}
-    },
     "recommendations": {
       "type": "product-recommendations",
       "settings": {
@@ -195,7 +186,6 @@
   },
   "order": [
     "main",
-    "details",
     "recommendations",
     "1743585275ab058f49"
   ]


### PR DESCRIPTION
## Summary
- integrate product info tabs within main product card
- implement overlay offcanvas for tab content and add JS logic
- remove standalone details section from product template

## Testing
- `theme-check` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689499a831148326b9924454bbce1a0c