### PR TITLE
Add product detail info tabs with offcanvas drawer

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -135,3 +135,22 @@
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
 }
+
+/* Product tabs */
+.product-info__tab:first-of-type .product-tab-btn {
+  border-top: 1px solid rgba(var(--text-color)/0.15);
+}
+.product-tab-btn {
+  width: 100%;
+  padding: 12px 0;
+  text-align: left;
+  background: none;
+  border: 0;
+  border-bottom: 1px solid rgba(var(--text-color)/0.15);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+.product-tab-btn:hover,
+.product-tab-btn:focus {
+  color: rgb(var(--link-color));
+}

--- a/assets/product-tabs.js
+++ b/assets/product-tabs.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.js-product-tab').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-target');
+      const drawer = document.getElementById(id);
+      if (drawer && typeof drawer.open === 'function') {
+        drawer.open(btn);
+      }
+    });
+  });
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -32,6 +32,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-tabs.js' | asset_url }}" defer="defer"></script>
 
 {%- liquid
   # constants
@@ -541,6 +542,25 @@
                 </button>
               </modal-opener>
               <a href="{{ block.settings.page.url }}" class="link js-hidden">{{ block.settings.link_text }}</a>
+            </div>
+
+          {%- when 'tab' -%}
+            <div class="product-info__block product-info__tab" {{ block.shopify_attributes }}>
+              <button type="button" class="product-tab-btn js-product-tab" data-target="tab-drawer-{{ block.id }}">
+                {{ block.settings.title }}
+              </button>
+              <side-drawer id="tab-drawer-{{ block.id }}" class="drawer" data-name="product-tab" aria-hidden="true">
+                <header class="drawer__header flex justify-between items-center">
+                  <h2 class="h4 mb-0">{{ block.settings.title }}</h2>
+                  <button type="button" class="drawer__close-btn js-close-drawer">
+                    {% render 'icon-close' %}
+                    <span class="visually-hidden">{{ 'accessibility.close' | t }}</span>
+                  </button>
+                </header>
+                <div class="drawer__content flex-auto rte">
+                  {{ block.settings.content }}
+                </div>
+              </side-drawer>
             </div>
 
           {%- when 'custom-liquid' -%}
@@ -1618,6 +1638,22 @@
         {
           "type": "paragraph",
           "content": "Customers who subscribe will have an account created for them. [Learn more](https://help.shopify.com/en/manual/customers/manage-customers)"
+        }
+      ]
+    },
+    {
+      "type": "tab",
+      "name": "Tab",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Title"
+        },
+        {
+          "type": "richtext",
+          "id": "content",
+          "label": "Content"
         }
       ]
     },

--- a/templates/product.json
+++ b/templates/product.json
@@ -71,6 +71,34 @@
             "custom_liquid": "<div class=\"cg-product-usps-card\">\n  <div class=\"cg-usps-row\">\n    <div class=\"cg-usp\">\n      <!-- Truck/Versandkostenfrei -->\n      <svg class=\"cg-usp-icon\" width=\"38\" height=\"38\" viewBox=\"0 0 16 16\" aria-hidden=\"true\" focusable=\"false\" role=\"presentation\">\n        <path fill=\"currentColor\" d=\"M15.64 6.92L9.5 5.12V4a.5.5 0 00-.5-.5H1a.5.5 0 00-.5.5v8.5c0 .28.22.5.5.5h1.27a2.1 2.1 0 004.06 0h3.94a2.1 2.1 0 004.06 0h1.17a.5.5 0 00.5-.5V7.4a.5.5 0 00-.36-.48zM4.3 13.6a1.1 1.1 0 110-2.2 1.1 1.1 0 010 2.2zM6.33 12a2.1 2.1 0 00-4.06 0H1.5V4.5h7V12H6.33zm5.97 1.6a1.1 1.1 0 110-2.2 1.1 1.1 0 010 2.2zM15 12h-.67a2.1 2.1 0 00-4.06 0H9.5V6.17l5.5 1.6V12z\"></path>\n      </svg>\n      <div class=\"cg-usp-text\">Versandkostenfrei</div>\n    </div>\n    <div class=\"cg-usp\">\n      <!-- Kreditkarte/Flexible Zahlungsarten -->\n      <svg class=\"cg-usp-icon\" width=\"38\" height=\"38\" viewBox=\"0 0 16 16\" aria-hidden=\"true\" focusable=\"false\" role=\"presentation\">\n        <rect stroke=\"currentColor\" fill=\"none\" x=\"0.92560589\" y=\"2.7769852\" width=\"14.231262\" height=\"10.350009\" rx=\"1.2937511\" ry=\"1.2937511\"></rect>\n        <line stroke=\"currentColor\" fill=\"none\" x1=\"0.92560589\" y1=\"6.6582384\" x2=\"15.156868\" y2=\"6.6582384\"></line>\n      </svg>\n      <div class=\"cg-usp-text\">Flexible Zahlungsarten</div>\n    </div>\n    <div class=\"cg-usp\">\n      <!-- 30 Tage Rückgabe -->\n      <svg class=\"cg-usp-icon\" width=\"38\" height=\"38\" viewBox=\"0 0 16 16\" aria-hidden=\"true\" focusable=\"false\" role=\"presentation\">\n        <path fill=\"currentColor\" d=\"M9 .5a.5.5 0 000 1h1a4.5 4.5 0 110 9H2.2l3.15-3.15a.5.5 0 10-.7-.7l-4 4a.5.5 0 000 .7l4 4a.5.5 0 00.7-.7L2.21 11.5H10a5.5 5.5 0 100-11H9z\"></path>\n      </svg>\n      <div class=\"cg-usp-text\">30 Tage Rückgabe</div>\n    </div>\n  </div>\n</div>"
           }
         },
+        "tab_description": {
+          "type": "tab",
+          "settings": {
+            "title": "Beschreibung",
+            "content": ""
+          }
+        },
+        "tab_manufacturer": {
+          "type": "tab",
+          "settings": {
+            "title": "Herstellerinformationen",
+            "content": ""
+          }
+        },
+        "tab_material": {
+          "type": "tab",
+          "settings": {
+            "title": "Material und Pflege",
+            "content": ""
+          }
+        },
+        "tab_faq": {
+          "type": "tab",
+          "settings": {
+            "title": "FAQs",
+            "content": ""
+          }
+        },
         "product-labels": {
           "type": "product-labels",
           "settings": {
@@ -95,6 +123,10 @@
         "variant-picker",
         "buy-buttons",
         "custom_liquid_kKPgLF",
+        "tab_description",
+        "tab_manufacturer",
+        "tab_material",
+        "tab_faq",
         "product-labels",
         "complementary_rx84bf"
       ],


### PR DESCRIPTION
## Summary
- integrate tab buttons for description, manufacturer info, material and FAQs inside product info card
- open tab content in right side offcanvas drawer
- add styling and JS for tab triggers

## Testing
- `npm test` *(fails: Could not read package.json)*
- `shopify version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68949d5bcfec83268fb1b2a9c34dfc91