### PR TITLE
Add product info tab blocks with offcanvas popup

### DIFF
--- a/assets/product-tabs.css
+++ b/assets/product-tabs.css
@@ -1,0 +1,48 @@
+.product-tab-button {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 0;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.product-tab-button:not(:last-child) {
+  margin-bottom: 0.25rem;
+}
+
+.product-tab-offcanvas {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 50;
+}
+
+.product-tab-offcanvas[hidden] {
+  display: none;
+}
+
+.product-tab-offcanvas__overlay {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.product-tab-offcanvas__drawer {
+  position: relative;
+  width: 80%;
+  max-width: 400px;
+  background: #fff;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.product-tab-offcanvas__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+}

--- a/assets/product-tabs.js
+++ b/assets/product-tabs.js
@@ -1,0 +1,16 @@
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.product-tab-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = document.getElementById(btn.dataset.tabTarget);
+      if (target) target.removeAttribute('hidden');
+    });
+  });
+
+  document.querySelectorAll('.product-tab-offcanvas').forEach((panel) => {
+    panel.addEventListener('click', (evt) => {
+      if (evt.target.hasAttribute('data-tab-close') || evt.target === panel) {
+        panel.setAttribute('hidden', true);
+      }
+    });
+  });
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -3,6 +3,9 @@
 {{ 'product.css' | asset_url | stylesheet_tag }}
 {{ 'product-page.css' | asset_url | stylesheet_tag }}
 
+{{ 'product-tabs.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'product-tabs.js' | asset_url }}" defer="defer"></script>
+
 
 {%- assign messages = section.blocks | where: "type", "message" -%}
 {%- if messages -%}
@@ -349,6 +352,21 @@
               {%- if block.settings.show_pickup_availability -%}
                 {% render 'pickup-availability', current_variant: current_variant %}
               {%- endif -%}
+            </div>
+
+          {%- when 'text' -%}
+            <div class="product-info__block" {{ block.shopify_attributes }}>
+              <button type="button" class="product-tab-button" data-tab-target="tab-{{ block.id }}">
+                {{ block.settings.tab_heading }}
+              </button>
+              <div id="tab-{{ block.id }}" class="product-tab-offcanvas" hidden>
+                <div class="product-tab-offcanvas__overlay" data-tab-close></div>
+                <div class="product-tab-offcanvas__drawer">
+                  <button type="button" class="product-tab-offcanvas__close" data-tab-close aria-label="{{ 'general.close' | t }}">&times;</button>
+                  <h2 class="product-tab-offcanvas__title">{{ block.settings.tab_heading }}</h2>
+                  <div class="product-tab-offcanvas__content rte">{{ block.settings.tab_content }}</div>
+                </div>
+              </div>
             </div>
 
           {%- when 'complementary' -%}
@@ -1183,6 +1201,23 @@
           "default": false,
           "label": "Show recipient information form for gift cards",
           "info": "Allow customers to send gift cards to a recipient along with a personal message. When enabled, the dynamic checkout button will be disabled for gift cards. [Learn more](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-gift-card-recipient-fields)"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "name": "Tab",
+      "limit": 4,
+      "settings": [
+        {
+          "type": "text",
+          "id": "tab_heading",
+          "label": "Heading"
+        },
+        {
+          "type": "richtext",
+          "id": "tab_content",
+          "label": "Content"
         }
       ]
     },

--- a/templates/product.json
+++ b/templates/product.json
@@ -68,6 +68,34 @@
             "show_gift_card_recipient": false
           }
         },
+        "tab_description": {
+          "type": "text",
+          "settings": {
+            "tab_heading": "Beschreibung",
+            "tab_content": "<p>Produktbeschreibung</p>"
+          }
+        },
+        "tab_manufacturer": {
+          "type": "text",
+          "settings": {
+            "tab_heading": "Herstellerinformationen",
+            "tab_content": "<p>Informationen zum Hersteller</p>"
+          }
+        },
+        "tab_material": {
+          "type": "text",
+          "settings": {
+            "tab_heading": "Material",
+            "tab_content": "<p>Materialangaben</p>"
+          }
+        },
+        "tab_faq": {
+          "type": "text",
+          "settings": {
+            "tab_heading": "FAQ",
+            "tab_content": "<p>Häufig gestellte Fragen</p>"
+          }
+        },
         "custom_liquid_kKPgLF": {
           "type": "custom-liquid",
           "settings": {
@@ -98,6 +126,10 @@
         "price",
         "variant-picker",
         "buy-buttons",
+        "tab_description",
+        "tab_manufacturer",
+        "tab_material",
+        "tab_faq",
         "custom_liquid_kKPgLF",
         "product-labels",
         "complementary_rx84bf"


### PR DESCRIPTION
## Summary
- add tab block schema and default blocks for description, manufacturer, material and FAQ
- render tab buttons under cart button with offcanvas panels
- include dedicated styles and JS for tab interactions

## Testing
- `npx @shopify/theme-check --init` *(fails: Not Found)*
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68958e5aea8883269ffe7368cf2ad610