### PR TITLE
Move product details into product card

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -682,6 +682,8 @@
             {%- endif -%}
         {%- endcase -%}
       {%- endfor -%}
+
+      {% section 'product-details' %}
       </div>
 
       {%- if section.settings.stick_on_scroll -%}

--- a/templates/product.coming-soon.json
+++ b/templates/product.coming-soon.json
@@ -1,1 +1,189 @@
-{"sections":{"main":{"type":"main-product","blocks":{"product-labels":{"type":"product-labels","settings":{}},"title":{"type":"title","settings":{}},"rating":{"type":"rating","settings":{}},"price":{"type":"price","settings":{"show_tax_and_shipping":false}},"message":{"type":"message","settings":{"icon":"calendar","title":"<h6>Coming Soon!<\/h6><p>We're so excited about our upcoming releases that we just couldn't keep them under wraps anymore! Drop us your email in the box below, and we'll let you know when it's good to go :)<\/p>","close":"none","show_over_media":false,"visibility_duration":7,"bg_color":"#f5f5f5","text_color":"#000000"}},"variant-picker":{"type":"variant-picker","settings":{"show_backorder_text":false}},"divider-1":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"product-signup":{"type":"product-signup","settings":{"heading":"","text":"<p>Sign up to be the first to know when it's here<\/p>"}},"share":{"type":"share","settings":{}}},"block_order":["product-labels","title","rating","price","message","variant-picker","divider-1","product-signup","share"],"settings":{"sticky_atc_panel":true,"hover_zoom":"large","media_thumbs":"always"}},"video":{"type":"video","blocks":{"video-heading":{"type":"heading","settings":{"heading_size":"h2","heading_h1":false}},"video-text":{"type":"text","settings":{"enlarge_text":true}}},"block_order":["video-heading","video-text"],"settings":{"video_size":"md","video_autoplay":true,"text_align":"text-center","color_scheme":"default"}},"details":{"type":"product-details","blocks":{"tabs":{"type":"tabs","settings":{"style":"collapsible","show_description":true,"show_reviews":true,"show_specification":true,"spec_right_align":true,"spec_show_empty_metafields":false}}},"block_order":["tabs"],"settings":{}},"scrolling-banner":{"type":"scrolling-banner","blocks":{"scrolling-banner-text-1":{"type":"text","settings":{"text":"Coming Soon!","link":"","font":"heading","heading_size":"h1"}},"scrolling-banner-text-2":{"type":"text","settings":{"text":"Coming Soon!","link":"","font":"body","heading_size":"h1"}}},"block_order":["scrolling-banner-text-1","scrolling-banner-text-2"],"settings":{"section_height":"medium","spacing":60,"speed":10,"direction":"normal","pausable":true,"color_scheme":"2","dividers":"none"}},"newsletter":{"type":"newsletter","blocks":{"newsletter-heading-1":{"type":"heading","settings":{"heading":"Be the first to know!","heading_size":"h3"}},"newsletter-text-2":{"type":"text","settings":{"text":"<p>Sign up for updates, and we'll let you know when it's arrived.<\/p>","enlarge_text":false}},"newsletter-form-3":{"type":"form","settings":{}}},"block_order":["newsletter-heading-1","newsletter-text-2","newsletter-form-3"],"settings":{}},"recommendations":{"type":"product-recommendations","settings":{"heading":"You may also like","heading_align":"text-start","layout":"carousel","card_size":"small","products_to_show":8}}},"order":["main","video","details","scrolling-banner","newsletter","recommendations"]}
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {}
+        },
+        "title": {
+          "type": "title",
+          "settings": {}
+        },
+        "rating": {
+          "type": "rating",
+          "settings": {}
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_tax_and_shipping": false
+          }
+        },
+        "message": {
+          "type": "message",
+          "settings": {
+            "icon": "calendar",
+            "title": "<h6>Coming Soon!</h6><p>We're so excited about our upcoming releases that we just couldn't keep them under wraps anymore! Drop us your email in the box below, and we'll let you know when it's good to go :)</p>",
+            "close": "none",
+            "show_over_media": false,
+            "visibility_duration": 7,
+            "bg_color": "#f5f5f5",
+            "text_color": "#000000"
+          }
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {
+            "show_backorder_text": false
+          }
+        },
+        "divider-1": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "product-signup": {
+          "type": "product-signup",
+          "settings": {
+            "heading": "",
+            "text": "<p>Sign up to be the first to know when it's here</p>"
+          }
+        },
+        "share": {
+          "type": "share",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "product-labels",
+        "title",
+        "rating",
+        "price",
+        "message",
+        "variant-picker",
+        "divider-1",
+        "product-signup",
+        "share"
+      ],
+      "settings": {
+        "sticky_atc_panel": true,
+        "hover_zoom": "large",
+        "media_thumbs": "always"
+      }
+    },
+    "video": {
+      "type": "video",
+      "blocks": {
+        "video-heading": {
+          "type": "heading",
+          "settings": {
+            "heading_size": "h2",
+            "heading_h1": false
+          }
+        },
+        "video-text": {
+          "type": "text",
+          "settings": {
+            "enlarge_text": true
+          }
+        }
+      },
+      "block_order": [
+        "video-heading",
+        "video-text"
+      ],
+      "settings": {
+        "video_size": "md",
+        "video_autoplay": true,
+        "text_align": "text-center",
+        "color_scheme": "default"
+      }
+    },
+    "scrolling-banner": {
+      "type": "scrolling-banner",
+      "blocks": {
+        "scrolling-banner-text-1": {
+          "type": "text",
+          "settings": {
+            "text": "Coming Soon!",
+            "link": "",
+            "font": "heading",
+            "heading_size": "h1"
+          }
+        },
+        "scrolling-banner-text-2": {
+          "type": "text",
+          "settings": {
+            "text": "Coming Soon!",
+            "link": "",
+            "font": "body",
+            "heading_size": "h1"
+          }
+        }
+      },
+      "block_order": [
+        "scrolling-banner-text-1",
+        "scrolling-banner-text-2"
+      ],
+      "settings": {
+        "section_height": "medium",
+        "spacing": 60,
+        "speed": 10,
+        "direction": "normal",
+        "pausable": true,
+        "color_scheme": "2",
+        "dividers": "none"
+      }
+    },
+    "newsletter": {
+      "type": "newsletter",
+      "blocks": {
+        "newsletter-heading-1": {
+          "type": "heading",
+          "settings": {
+            "heading": "Be the first to know!",
+            "heading_size": "h3"
+          }
+        },
+        "newsletter-text-2": {
+          "type": "text",
+          "settings": {
+            "text": "<p>Sign up for updates, and we'll let you know when it's arrived.</p>",
+            "enlarge_text": false
+          }
+        },
+        "newsletter-form-3": {
+          "type": "form",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "newsletter-heading-1",
+        "newsletter-text-2",
+        "newsletter-form-3"
+      ],
+      "settings": {}
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "heading": "You may also like",
+        "heading_align": "text-start",
+        "layout": "carousel",
+        "card_size": "small",
+        "products_to_show": 8
+      }
+    }
+  },
+  "order": [
+    "main",
+    "video",
+    "scrolling-banner",
+    "newsletter",
+    "recommendations"
+  ]
+}

--- a/templates/product.countdown.json
+++ b/templates/product.countdown.json
@@ -1,1 +1,264 @@
-{"sections":{"countdown-timer":{"type":"countdown-timer","blocks":{"countdown-subheading":{"type":"subheading","settings":{"text":"Product name here"}},"countdown-heading":{"type":"heading","settings":{"heading":"Launching soon!","heading_size":"h3"}},"countdown-text":{"type":"text","settings":{"text":"<p>The countdown is on...<\/p>","enlarge_text":true}},"countdown-countdown":{"type":"countdown","settings":{}}},"block_order":["countdown-subheading","countdown-heading","countdown-text","countdown-countdown"],"settings":{"height_mode":"fixed","fixed_height_desktop":400,"fixed_height_mobile":350,"overlay_position":"justify-center","text_align":"text-center","mob_center_text":true,"countdown_size":"24","color_scheme":"1","full_width":true,"tint_opacity":0}},"main":{"type":"main-product","blocks":{"product-labels":{"type":"product-labels","settings":{}},"title":{"type":"title","settings":{}},"rating":{"type":"rating","settings":{}},"price":{"type":"price","settings":{"show_tax_and_shipping":false}},"divider-0":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"message-1":{"type":"message","settings":{"icon":"calendar","title":"<h6>Coming Soon!<\/h6><p>We're so excited about our upcoming releases that we just couldn't keep them under wraps anymore! Drop us your email in the box below, and we'll let you know when it's good to go :)<\/p>","close":"none","show_over_media":false,"visibility_duration":7,"bg_color":"#f5f5f5","text_color":"#000000"}},"divider-1":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"variant-picker":{"type":"variant-picker","settings":{"selector_style":"buttons","enable_dynamic_availability":true,"show_backorder_text":false,"enable_size_chart":false,"size_chart_variant":"Size","size_chart_page":""}},"divider-2":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"product-signup":{"type":"product-signup","settings":{"heading":"","text":"<p>Sign up to be the first to know when it's here<\/p>"}},"divider-3":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"share":{"type":"share","settings":{}}},"block_order":["product-labels","title","rating","price","divider-0","message-1","divider-1","variant-picker","divider-2","product-signup","divider-3","share"],"settings":{"sticky_atc_panel":true,"hover_zoom":"large","media_thumbs":"always"}},"video":{"type":"video","blocks":{"video-heading":{"type":"heading","settings":{"heading_size":"h2","heading_h1":false}},"video-text":{"type":"text","settings":{"enlarge_text":true}}},"block_order":["video-heading","video-text"],"settings":{"video_size":"md","video_autoplay":true,"text_align":"text-center","color_scheme":"default"}},"details":{"type":"product-details","blocks":{"tabs":{"type":"tabs","settings":{"style":"collapsible","show_description":true,"show_reviews":true,"show_specification":true,"spec_right_align":true,"spec_show_empty_metafields":false}},"highlight-text":{"type":"highlight-text","settings":{}}},"block_order":["tabs","highlight-text"],"settings":{}},"scrolling-banner":{"type":"scrolling-banner","blocks":{"scrolling-banner-text-1":{"type":"text","settings":{"text":"Coming Soon!","font":"heading","heading_size":"h1"}},"scrolling-banner-text-2":{"type":"text","settings":{"text":"Coming Soon!","font":"body","heading_size":"h1"}}},"block_order":["scrolling-banner-text-1","scrolling-banner-text-2"],"settings":{"section_height":"medium","spacing":60,"speed":10,"direction":"normal","pausable":true,"color_scheme":"2","dividers":"none"}},"newsletter":{"type":"newsletter","blocks":{"newsletter-heading-1":{"type":"heading","settings":{"heading":"Be the first to know!","heading_size":"h3"}},"newsletter-text-2":{"type":"text","settings":{"text":"<p>Sign up for updates, and we'll let you know when it's arrived.<\/p>","enlarge_text":false}},"newsletter-form-3":{"type":"form","settings":{}}},"block_order":["newsletter-heading-1","newsletter-text-2","newsletter-form-3"],"settings":{}},"recommendations":{"type":"product-recommendations","settings":{"heading":"You may also like","heading_align":"text-start","layout":"carousel","card_size":"small","products_to_show":8}}},"order":["countdown-timer","main","video","details","scrolling-banner","newsletter","recommendations"]}
+{
+  "sections": {
+    "countdown-timer": {
+      "type": "countdown-timer",
+      "blocks": {
+        "countdown-subheading": {
+          "type": "subheading",
+          "settings": {
+            "text": "Product name here"
+          }
+        },
+        "countdown-heading": {
+          "type": "heading",
+          "settings": {
+            "heading": "Launching soon!",
+            "heading_size": "h3"
+          }
+        },
+        "countdown-text": {
+          "type": "text",
+          "settings": {
+            "text": "<p>The countdown is on...</p>",
+            "enlarge_text": true
+          }
+        },
+        "countdown-countdown": {
+          "type": "countdown",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "countdown-subheading",
+        "countdown-heading",
+        "countdown-text",
+        "countdown-countdown"
+      ],
+      "settings": {
+        "height_mode": "fixed",
+        "fixed_height_desktop": 400,
+        "fixed_height_mobile": 350,
+        "overlay_position": "justify-center",
+        "text_align": "text-center",
+        "mob_center_text": true,
+        "countdown_size": "24",
+        "color_scheme": "1",
+        "full_width": true,
+        "tint_opacity": 0
+      }
+    },
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {}
+        },
+        "title": {
+          "type": "title",
+          "settings": {}
+        },
+        "rating": {
+          "type": "rating",
+          "settings": {}
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_tax_and_shipping": false
+          }
+        },
+        "divider-0": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "message-1": {
+          "type": "message",
+          "settings": {
+            "icon": "calendar",
+            "title": "<h6>Coming Soon!</h6><p>We're so excited about our upcoming releases that we just couldn't keep them under wraps anymore! Drop us your email in the box below, and we'll let you know when it's good to go :)</p>",
+            "close": "none",
+            "show_over_media": false,
+            "visibility_duration": 7,
+            "bg_color": "#f5f5f5",
+            "text_color": "#000000"
+          }
+        },
+        "divider-1": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {
+            "selector_style": "buttons",
+            "enable_dynamic_availability": true,
+            "show_backorder_text": false,
+            "enable_size_chart": false,
+            "size_chart_variant": "Size",
+            "size_chart_page": ""
+          }
+        },
+        "divider-2": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "product-signup": {
+          "type": "product-signup",
+          "settings": {
+            "heading": "",
+            "text": "<p>Sign up to be the first to know when it's here</p>"
+          }
+        },
+        "divider-3": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "share": {
+          "type": "share",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "product-labels",
+        "title",
+        "rating",
+        "price",
+        "divider-0",
+        "message-1",
+        "divider-1",
+        "variant-picker",
+        "divider-2",
+        "product-signup",
+        "divider-3",
+        "share"
+      ],
+      "settings": {
+        "sticky_atc_panel": true,
+        "hover_zoom": "large",
+        "media_thumbs": "always"
+      }
+    },
+    "video": {
+      "type": "video",
+      "blocks": {
+        "video-heading": {
+          "type": "heading",
+          "settings": {
+            "heading_size": "h2",
+            "heading_h1": false
+          }
+        },
+        "video-text": {
+          "type": "text",
+          "settings": {
+            "enlarge_text": true
+          }
+        }
+      },
+      "block_order": [
+        "video-heading",
+        "video-text"
+      ],
+      "settings": {
+        "video_size": "md",
+        "video_autoplay": true,
+        "text_align": "text-center",
+        "color_scheme": "default"
+      }
+    },
+    "scrolling-banner": {
+      "type": "scrolling-banner",
+      "blocks": {
+        "scrolling-banner-text-1": {
+          "type": "text",
+          "settings": {
+            "text": "Coming Soon!",
+            "font": "heading",
+            "heading_size": "h1"
+          }
+        },
+        "scrolling-banner-text-2": {
+          "type": "text",
+          "settings": {
+            "text": "Coming Soon!",
+            "font": "body",
+            "heading_size": "h1"
+          }
+        }
+      },
+      "block_order": [
+        "scrolling-banner-text-1",
+        "scrolling-banner-text-2"
+      ],
+      "settings": {
+        "section_height": "medium",
+        "spacing": 60,
+        "speed": 10,
+        "direction": "normal",
+        "pausable": true,
+        "color_scheme": "2",
+        "dividers": "none"
+      }
+    },
+    "newsletter": {
+      "type": "newsletter",
+      "blocks": {
+        "newsletter-heading-1": {
+          "type": "heading",
+          "settings": {
+            "heading": "Be the first to know!",
+            "heading_size": "h3"
+          }
+        },
+        "newsletter-text-2": {
+          "type": "text",
+          "settings": {
+            "text": "<p>Sign up for updates, and we'll let you know when it's arrived.</p>",
+            "enlarge_text": false
+          }
+        },
+        "newsletter-form-3": {
+          "type": "form",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "newsletter-heading-1",
+        "newsletter-text-2",
+        "newsletter-form-3"
+      ],
+      "settings": {}
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "heading": "You may also like",
+        "heading_align": "text-start",
+        "layout": "carousel",
+        "card_size": "small",
+        "products_to_show": 8
+      }
+    }
+  },
+  "order": [
+    "countdown-timer",
+    "main",
+    "video",
+    "scrolling-banner",
+    "newsletter",
+    "recommendations"
+  ]
+}

--- a/templates/product.json
+++ b/templates/product.json
@@ -134,40 +134,6 @@
         "media_grouping_option": "Color,Colour,Couleur,Farbe"
       }
     },
-    "details": {
-      "type": "product-details",
-      "blocks": {
-        "tabs": {
-          "type": "tabs",
-          "settings": {
-            "style": "tabs",
-            "open_first": false,
-            "show_description": true,
-            "show_reviews": false,
-            "custom_reviews": "",
-            "show_specification": false,
-            "spec_metafields": "Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten",
-            "spec_right_align": false,
-            "spec_show_empty_metafields": false,
-            "spec_empty_field_text": "-",
-            "tab_1_title": "Herstellerinformationen",
-            "tab_1_text": "<p><strong>Herstellerinformationen: </strong></p><p>{{ product.metafields.custom.herstellerinformationen | metafield_tag }}</p><p><strong>Importeur: </strong></p><p>{{ product.metafields.custom.importeur | metafield_tag }}</p><p><strong>EU-Verantwortliche Person:</strong></p><p>{{ product.metafields.custom.eu_verantwortliche_person | metafield_tag }}</p><p></p>",
-            "tab_1_page": "",
-            "tab_2_title": "",
-            "tab_2_text": "",
-            "tab_2_page": "",
-            "tab_3_title": "",
-            "tab_3_text": "",
-            "tab_3_page": ""
-          }
-        }
-      },
-      "block_order": [
-        "tabs"
-      ],
-      "custom_css": [],
-      "settings": {}
-    },
     "recommendations": {
       "type": "product-recommendations",
       "settings": {
@@ -199,7 +165,6 @@
   },
   "order": [
     "main",
-    "details",
     "recommendations",
     "1743585275ab058f49"
   ]

--- a/templates/product.preorder.json
+++ b/templates/product.preorder.json
@@ -1,1 +1,80 @@
-{"sections":{"main":{"type":"main-product","blocks":{"vendor-sku":{"type":"vendor-sku","settings":{}},"product-labels":{"type":"product-labels","settings":{}},"title":{"type":"title","settings":{}},"price":{"type":"price","settings":{}},"divider-0":{"type":"divider","settings":{}},"variant-picker":{"type":"variant-picker","settings":{}},"divider-1":{"type":"divider","settings":{}},"buy-buttons":{"type":"buy-buttons","settings":{"show_pickup_availability":false}},"message-1":{"type":"message","settings":{"icon":"none","title":"<p><strong>Pre-order now to make sure you don't miss out!<\/strong><br\/><br\/>As soon as it's in stock, we will ship it to you.<\/p>","close":"once","show_over_media":false}},"newsletter":{"type":"newsletter-signup","settings":{"heading":"Subscribe to our newsletter","text":"<p>Get the latest updates on all our new collections, sales, offers and product arrival dates.<\/p>"}}},"block_order":["vendor-sku","product-labels","title","price","divider-0","variant-picker","divider-1","buy-buttons","message-1","newsletter"],"settings":{}},"details":{"type":"product-details","blocks":{"highlight-text":{"type":"highlight-text","settings":{}},"tabs":{"type":"tabs","settings":{"style":"collapsible","show_description":true}},"payment-methods":{"type":"payment-methods","settings":{}}},"block_order":["highlight-text","tabs","payment-methods"],"settings":{}},"recommendations":{"type":"product-recommendations","settings":{}}},"order":["main","details","recommendations"]}
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "vendor-sku": {
+          "type": "vendor-sku",
+          "settings": {}
+        },
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {}
+        },
+        "title": {
+          "type": "title",
+          "settings": {}
+        },
+        "price": {
+          "type": "price",
+          "settings": {}
+        },
+        "divider-0": {
+          "type": "divider",
+          "settings": {}
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {}
+        },
+        "divider-1": {
+          "type": "divider",
+          "settings": {}
+        },
+        "buy-buttons": {
+          "type": "buy-buttons",
+          "settings": {
+            "show_pickup_availability": false
+          }
+        },
+        "message-1": {
+          "type": "message",
+          "settings": {
+            "icon": "none",
+            "title": "<p><strong>Pre-order now to make sure you don't miss out!</strong><br/><br/>As soon as it's in stock, we will ship it to you.</p>",
+            "close": "once",
+            "show_over_media": false
+          }
+        },
+        "newsletter": {
+          "type": "newsletter-signup",
+          "settings": {
+            "heading": "Subscribe to our newsletter",
+            "text": "<p>Get the latest updates on all our new collections, sales, offers and product arrival dates.</p>"
+          }
+        }
+      },
+      "block_order": [
+        "vendor-sku",
+        "product-labels",
+        "title",
+        "price",
+        "divider-0",
+        "variant-picker",
+        "divider-1",
+        "buy-buttons",
+        "message-1",
+        "newsletter"
+      ],
+      "settings": {}
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {}
+    }
+  },
+  "order": [
+    "main",
+    "recommendations"
+  ]
+}

--- a/templates/product.special.json
+++ b/templates/product.special.json
@@ -1,1 +1,192 @@
-{"sections":{"main":{"type":"main-product","blocks":{"vendor-sku":{"type":"vendor-sku","settings":{"show_vendor":true,"show_sku":true,"show_barcode":false}},"product-labels":{"type":"product-labels","settings":{"show_variant_icon":true}},"title":{"type":"title","settings":{"show_weight":false}},"divider_gtUcUd":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"inventory_status_Jhajhy":{"type":"inventory-status","settings":{"show_indicator_bar":true,"show_urgency_message":true,"text_very_low":"<p>- Fast ausverkauft!<\/p>","text_low":"<p>- Fast ausverkauft!<\/p>","text_normal":"","text_no_stock":"<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.<\/p>","text_no_stock_backordered":""}},"custom_liquid_rBmMbp":{"type":"custom-liquid","settings":{"custom_liquid":"{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage<\/p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar<\/p>\n{% endif %}"}},"divider-0":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"price":{"type":"price","settings":{"show_tax_and_shipping":true}},"divider_fbkn9A":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"variant-picker":{"type":"variant-picker","settings":{"selector_style":"buttons","enable_dynamic_availability":true,"dynamic_availability_downwards":false,"show_backorder_text":true,"enable_size_chart":false,"size_chart_variant":"Size","size_chart_page":""}},"buy-buttons":{"type":"buy-buttons","settings":{"show_qty_selector":true,"enable_dynamic_checkout":true,"show_pickup_availability":true,"show_gift_card_recipient":false}},"complementary_rx84bf":{"type":"complementary","settings":{"heading":"Passend dazu!","products_to_show":4,"layout":"carousel"}},"collapsible-content-2":{"type":"collapsible-content","settings":{"heading":"Versand","icon":"truck","text":"<p>Kostenloser Versand innerhalb Deutschland.<\/p>","page":"","open":false}},"collapsible_content_3HkYGJ":{"type":"collapsible-content","settings":{"heading":"Rückgabe","icon":"return","text":"<p>30 Tage Rückgaberecht.<\/p>","page":"","open":false}}},"block_order":["vendor-sku","product-labels","title","divider_gtUcUd","inventory_status_Jhajhy","custom_liquid_rBmMbp","divider-0","price","divider_fbkn9A","variant-picker","buy-buttons","complementary_rx84bf","collapsible-content-2","collapsible_content_3HkYGJ"],"settings":{"stick_on_scroll":true,"select_first_variant":true,"sticky_atc_panel":true,"sticky_atc_position":"end","sticky_atc_mobile":true,"media_layout":"slider","media_size":"default","media_ratio":"1","media_crop":"none","enable_video_looping":false,"enable_zoom":true,"zoom_mode":"hover","enable_lightbox_mobile":false,"hover_zoom":"large","stacked_scroll":"always","underline_active":true,"media_arrows":"desktop","show_slide_count":true,"media_thumbs":"desktop","lightbox_thumbnails":true,"thumb_ratio":"1","thumb_crop":"none","border_color":"#eeeeee","bg_color":"#f4f4f4","enable_media_grouping":true,"media_grouping_option":"Color,Colour,Couleur,Farbe"}},"details":{"type":"product-details","blocks":{"tabs":{"type":"tabs","settings":{"style":"tabs","open_first":false,"show_description":true,"show_reviews":false,"custom_reviews":"","show_specification":true,"spec_metafields":"Kompatibel für: custom.kompatibel_f_r\nDisplaygröße: custom.displaygr_e\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nMaterial: custom.material\nOutput: custom.output\nBesonderheiten: custom.besonderheiten\nHerstellerinformationen: custom.herstellerinformationen\nEU Verantwortliche Person:custom.eu_verantwortliche_person\nImporteur:custom.importeur","spec_right_align":false,"spec_show_empty_metafields":false,"spec_empty_field_text":"-","tab_1_title":"","tab_1_text":"","tab_1_page":"","tab_2_title":"","tab_2_text":"","tab_2_page":"","tab_3_title":"","tab_3_text":"","tab_3_page":""}}},"block_order":["tabs"],"settings":{}},"17200888731a472e47":{"type":"apps","settings":{"full_width":false}},"recommendations":{"type":"product-recommendations","settings":{"heading":"Das könnte dir auch gefallen","heading_align":"text-start","layout":"carousel","card_size_mobile":"small","card_size":"small","products_to_show":8}}},"order":["main","details","17200888731a472e47","recommendations"]}
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "vendor-sku": {
+          "type": "vendor-sku",
+          "settings": {
+            "show_vendor": true,
+            "show_sku": true,
+            "show_barcode": false
+          }
+        },
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {
+            "show_variant_icon": true
+          }
+        },
+        "title": {
+          "type": "title",
+          "settings": {
+            "show_weight": false
+          }
+        },
+        "divider_gtUcUd": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "inventory_status_Jhajhy": {
+          "type": "inventory-status",
+          "settings": {
+            "show_indicator_bar": true,
+            "show_urgency_message": true,
+            "text_very_low": "<p>- Fast ausverkauft!</p>",
+            "text_low": "<p>- Fast ausverkauft!</p>",
+            "text_normal": "",
+            "text_no_stock": "<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.</p>",
+            "text_no_stock_backordered": ""
+          }
+        },
+        "custom_liquid_rBmMbp": {
+          "type": "custom-liquid",
+          "settings": {
+            "custom_liquid": "{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage</p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar</p>\n{% endif %}"
+          }
+        },
+        "divider-0": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_tax_and_shipping": true
+          }
+        },
+        "divider_fbkn9A": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {
+            "selector_style": "buttons",
+            "enable_dynamic_availability": true,
+            "dynamic_availability_downwards": false,
+            "show_backorder_text": true,
+            "enable_size_chart": false,
+            "size_chart_variant": "Size",
+            "size_chart_page": ""
+          }
+        },
+        "buy-buttons": {
+          "type": "buy-buttons",
+          "settings": {
+            "show_qty_selector": true,
+            "enable_dynamic_checkout": true,
+            "show_pickup_availability": true,
+            "show_gift_card_recipient": false
+          }
+        },
+        "complementary_rx84bf": {
+          "type": "complementary",
+          "settings": {
+            "heading": "Passend dazu!",
+            "products_to_show": 4,
+            "layout": "carousel"
+          }
+        },
+        "collapsible-content-2": {
+          "type": "collapsible-content",
+          "settings": {
+            "heading": "Versand",
+            "icon": "truck",
+            "text": "<p>Kostenloser Versand innerhalb Deutschland.</p>",
+            "page": "",
+            "open": false
+          }
+        },
+        "collapsible_content_3HkYGJ": {
+          "type": "collapsible-content",
+          "settings": {
+            "heading": "Rückgabe",
+            "icon": "return",
+            "text": "<p>30 Tage Rückgaberecht.</p>",
+            "page": "",
+            "open": false
+          }
+        }
+      },
+      "block_order": [
+        "vendor-sku",
+        "product-labels",
+        "title",
+        "divider_gtUcUd",
+        "inventory_status_Jhajhy",
+        "custom_liquid_rBmMbp",
+        "divider-0",
+        "price",
+        "divider_fbkn9A",
+        "variant-picker",
+        "buy-buttons",
+        "complementary_rx84bf",
+        "collapsible-content-2",
+        "collapsible_content_3HkYGJ"
+      ],
+      "settings": {
+        "stick_on_scroll": true,
+        "select_first_variant": true,
+        "sticky_atc_panel": true,
+        "sticky_atc_position": "end",
+        "sticky_atc_mobile": true,
+        "media_layout": "slider",
+        "media_size": "default",
+        "media_ratio": "1",
+        "media_crop": "none",
+        "enable_video_looping": false,
+        "enable_zoom": true,
+        "zoom_mode": "hover",
+        "enable_lightbox_mobile": false,
+        "hover_zoom": "large",
+        "stacked_scroll": "always",
+        "underline_active": true,
+        "media_arrows": "desktop",
+        "show_slide_count": true,
+        "media_thumbs": "desktop",
+        "lightbox_thumbnails": true,
+        "thumb_ratio": "1",
+        "thumb_crop": "none",
+        "border_color": "#eeeeee",
+        "bg_color": "#f4f4f4",
+        "enable_media_grouping": true,
+        "media_grouping_option": "Color,Colour,Couleur,Farbe"
+      }
+    },
+    "17200888731a472e47": {
+      "type": "apps",
+      "settings": {
+        "full_width": false
+      }
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "heading": "Das könnte dir auch gefallen",
+        "heading_align": "text-start",
+        "layout": "carousel",
+        "card_size_mobile": "small",
+        "card_size": "small",
+        "products_to_show": 8
+      }
+    }
+  },
+  "order": [
+    "main",
+    "17200888731a472e47",
+    "recommendations"
+  ]
+}

--- a/templates/product.testproduktseite.json
+++ b/templates/product.testproduktseite.json
@@ -1,1 +1,275 @@
-{"sections":{"main":{"type":"main-product","blocks":{"vendor-sku":{"type":"vendor-sku","settings":{"show_vendor":false,"show_sku":true,"show_barcode":false}},"title":{"type":"title","settings":{"show_weight":false}},"inventory_status_Jhajhy":{"type":"inventory-status","settings":{"show_indicator_bar":true,"show_urgency_message":true,"text_very_low":"<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage<\/p>","text_low":"<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage<\/p>","text_normal":"<p>| Lieferzeit 1-3 Tage<\/p>","text_no_stock":"<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.<\/p>","text_no_stock_backordered":"<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.<\/p>"}},"divider_gtUcUd":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"custom_liquid_rBmMbp":{"type":"custom-liquid","disabled":true,"settings":{"custom_liquid":"{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage<\/p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar<\/p>\n{% endif %}"}},"price":{"type":"price","settings":{"show_tax_and_shipping":true}},"divider-0":{"type":"divider","settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"product-labels":{"type":"product-labels","settings":{"show_variant_icon":true}},"divider_fbkn9A":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"variant-picker":{"type":"variant-picker","settings":{"selector_style":"buttons","enable_dynamic_availability":true,"dynamic_availability_downwards":false,"show_backorder_text":true,"enable_size_chart":false,"size_chart_variant":"Size","size_chart_page":""}},"buy-buttons":{"type":"buy-buttons","settings":{"show_qty_selector":true,"enable_dynamic_checkout":true,"show_pickup_availability":true,"show_gift_card_recipient":false}},"complementary_rx84bf":{"type":"complementary","settings":{"heading":"Passend dazu!","products_to_show":4,"layout":"list"}},"collapsible-content-2":{"type":"collapsible-content","disabled":true,"settings":{"heading":"Versand","icon":"truck","text":"<p>Klimafreundlicher kostenloser Versand innerhalb Deutschland.<\/p>","page":"","open":false}},"collapsible_content_3HkYGJ":{"type":"collapsible-content","disabled":true,"settings":{"heading":"Rückgabe","icon":"return","text":"<p>30 Tage Rückgaberecht.<\/p>","page":"","open":false}},"description_Nz7fFB":{"type":"description","settings":{"show_as_collapsible_content":true,"icon":"eye","open":false}}},"block_order":["vendor-sku","title","inventory_status_Jhajhy","divider_gtUcUd","custom_liquid_rBmMbp","price","divider-0","product-labels","divider_fbkn9A","variant-picker","buy-buttons","complementary_rx84bf","collapsible-content-2","collapsible_content_3HkYGJ","description_Nz7fFB"],"settings":{"stick_on_scroll":true,"select_first_variant":true,"sticky_atc_panel":true,"sticky_atc_position":"end","sticky_atc_mobile":true,"media_layout":"slider","media_size":"default","media_ratio":"natural","media_crop":"none","enable_video_looping":false,"enable_zoom":true,"zoom_mode":"hover","enable_lightbox_mobile":false,"hover_zoom":"medium","stacked_scroll":"always","underline_active":true,"media_arrows":"desktop","show_slide_count":true,"media_thumbs":"desktop","lightbox_thumbnails":true,"thumb_ratio":"1","thumb_crop":"none","border_color":"#eeeeee","bg_color":"#f4f4f4","enable_media_grouping":true,"media_grouping_option":"Color,Colour,Couleur,Farbe"}},"icons_with_text_8yNjYG":{"type":"icons-with-text","blocks":{"item_RNjhbX":{"type":"item","settings":{"icon":"truck","heading":"Free shipping","text":"<p>On all orders over $100<\/p>","link":""}},"item_M6WDyn":{"type":"item","settings":{"icon":"price_tag","heading":"Special offers","text":"<p>Regular sales and discounts<\/p>","link":""}},"item_GkUzBU":{"type":"item","settings":{"icon":"return","heading":"Easy returns","text":"<p>Hassle free returns policy<\/p>","link":""}},"item_Ad3a4K":{"type":"item","settings":{"icon":"chat_bubble","heading":"Chat facility","text":"<p>Talk to a real person<\/p>","link":""}}},"block_order":["item_RNjhbX","item_M6WDyn","item_GkUzBU","item_Ad3a4K"],"settings":{"heading":"","heading_align":"text-start","icon_size":48,"title_type_scale":"medium","text_type_scale":"medium","icon_position":"beside","mobile_stack":false,"section_height":"medium","color_scheme":"none","full_width":true,"dividers":"border-bottom","prevent_animation":false}},"custom_liquid_PAtp9p":{"type":"custom-liquid","settings":{"custom_liquid":"{% comment %}\nCustom Liquid Snippet für collapsible Content\n\nDieses Snippet zeigt die folgenden Metafelder nur an, wenn diese einen Inhalt haben:\n- custom.importeur\n- custom.herstellerinformationen\n- custom.eu_verantwortliche_person\n\nSpeichere diesen Code z. B. als \"custom-collapsible-specs.liquid\" in deinem Snippets-Ordner\nund binde ihn in deiner Produktseite mit:\n{% raw %}{% render 'custom-collapsible-specs' %}{% endraw %}\nein.\n{% endcomment %}\n\n<style>\n  \/* Grundlegende Styles für collapsible Abschnitte *\/\n  .collapsible-section {\n    border: 1px solid #ccc;\n    border-radius: 4px;\n    margin-bottom: 20px;\n    overflow: hidden;\n  }\n  .collapsible-section summary {\n    cursor: pointer;\n    padding: 10px 15px;\n    background-color: #f5f5f5;\n    font-weight: bold;\n    outline: none;\n  }\n  .collapsible-section[open] summary {\n    border-bottom: 1px solid #ccc;\n  }\n  .collapsible-section .collapsible-content {\n    padding: 15px;\n    background-color: #fff;\n    line-height: 1.5;\n    color: #333;\n  }\n<\/style>\n\n<div class=\"product-collapsible\">\n  {% if product.metafields.custom.importeur and product.metafields.custom.importeur.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>Importeur<\/summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.importeur.value }}\n      <\/div>\n    <\/details>\n  {% endif %}\n\n  {% if product.metafields.custom.herstellerinformationen and product.metafields.custom.herstellerinformationen.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>Herstellerinformationen<\/summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.herstellerinformationen.value }}\n      <\/div>\n    <\/details>\n  {% endif %}\n\n  {% if product.metafields.custom.eu_verantwortliche_person and product.metafields.custom.eu_verantwortliche_person.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>EU Verantwortliche Person<\/summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.eu_verantwortliche_person.value }}\n      <\/div>\n    <\/details>\n  {% endif %}\n<\/div>","section_height":"default","full_width":false,"dividers":"none","prevent_animation":false}},"details":{"type":"product-details","blocks":{"tabs":{"type":"tabs","settings":{"style":"tabs","open_first":false,"show_description":true,"show_reviews":true,"custom_reviews":"","show_specification":true,"spec_metafields":"Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nDisplaygröße: custom.displaygr_e\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten\nHerstellerinformationen: custom.herstellerinformationen\nEU Verantwortliche Person:custom.eu_verantwortliche_person\nImporteur:custom.importeur","spec_right_align":true,"spec_show_empty_metafields":false,"spec_empty_field_text":"-","tab_1_title":"","tab_1_text":"","tab_1_page":"","tab_2_title":"","tab_2_text":"","tab_2_page":"","tab_3_title":"","tab_3_text":"","tab_3_page":""}}},"block_order":["tabs"],"disabled":true,"custom_css":[],"settings":{}},"17200888731a472e47":{"type":"apps","settings":{"full_width":false}},"recommendations":{"type":"product-recommendations","settings":{"heading":"Das könnte Ihnen auch gefallen","heading_align":"text-start","layout":"carousel","card_size_mobile":"small","card_size":"small","products_to_show":8}}},"order":["main","icons_with_text_8yNjYG","custom_liquid_PAtp9p","details","17200888731a472e47","recommendations"]}
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "vendor-sku": {
+          "type": "vendor-sku",
+          "settings": {
+            "show_vendor": false,
+            "show_sku": true,
+            "show_barcode": false
+          }
+        },
+        "title": {
+          "type": "title",
+          "settings": {
+            "show_weight": false
+          }
+        },
+        "inventory_status_Jhajhy": {
+          "type": "inventory-status",
+          "settings": {
+            "show_indicator_bar": true,
+            "show_urgency_message": true,
+            "text_very_low": "<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage</p>",
+            "text_low": "<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage</p>",
+            "text_normal": "<p>| Lieferzeit 1-3 Tage</p>",
+            "text_no_stock": "<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.</p>",
+            "text_no_stock_backordered": "<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.</p>"
+          }
+        },
+        "divider_gtUcUd": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "custom_liquid_rBmMbp": {
+          "type": "custom-liquid",
+          "disabled": true,
+          "settings": {
+            "custom_liquid": "{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage</p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar</p>\n{% endif %}"
+          }
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_tax_and_shipping": true
+          }
+        },
+        "divider-0": {
+          "type": "divider",
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {
+            "show_variant_icon": true
+          }
+        },
+        "divider_fbkn9A": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {
+            "selector_style": "buttons",
+            "enable_dynamic_availability": true,
+            "dynamic_availability_downwards": false,
+            "show_backorder_text": true,
+            "enable_size_chart": false,
+            "size_chart_variant": "Size",
+            "size_chart_page": ""
+          }
+        },
+        "buy-buttons": {
+          "type": "buy-buttons",
+          "settings": {
+            "show_qty_selector": true,
+            "enable_dynamic_checkout": true,
+            "show_pickup_availability": true,
+            "show_gift_card_recipient": false
+          }
+        },
+        "complementary_rx84bf": {
+          "type": "complementary",
+          "settings": {
+            "heading": "Passend dazu!",
+            "products_to_show": 4,
+            "layout": "list"
+          }
+        },
+        "collapsible-content-2": {
+          "type": "collapsible-content",
+          "disabled": true,
+          "settings": {
+            "heading": "Versand",
+            "icon": "truck",
+            "text": "<p>Klimafreundlicher kostenloser Versand innerhalb Deutschland.</p>",
+            "page": "",
+            "open": false
+          }
+        },
+        "collapsible_content_3HkYGJ": {
+          "type": "collapsible-content",
+          "disabled": true,
+          "settings": {
+            "heading": "Rückgabe",
+            "icon": "return",
+            "text": "<p>30 Tage Rückgaberecht.</p>",
+            "page": "",
+            "open": false
+          }
+        },
+        "description_Nz7fFB": {
+          "type": "description",
+          "settings": {
+            "show_as_collapsible_content": true,
+            "icon": "eye",
+            "open": false
+          }
+        }
+      },
+      "block_order": [
+        "vendor-sku",
+        "title",
+        "inventory_status_Jhajhy",
+        "divider_gtUcUd",
+        "custom_liquid_rBmMbp",
+        "price",
+        "divider-0",
+        "product-labels",
+        "divider_fbkn9A",
+        "variant-picker",
+        "buy-buttons",
+        "complementary_rx84bf",
+        "collapsible-content-2",
+        "collapsible_content_3HkYGJ",
+        "description_Nz7fFB"
+      ],
+      "settings": {
+        "stick_on_scroll": true,
+        "select_first_variant": true,
+        "sticky_atc_panel": true,
+        "sticky_atc_position": "end",
+        "sticky_atc_mobile": true,
+        "media_layout": "slider",
+        "media_size": "default",
+        "media_ratio": "natural",
+        "media_crop": "none",
+        "enable_video_looping": false,
+        "enable_zoom": true,
+        "zoom_mode": "hover",
+        "enable_lightbox_mobile": false,
+        "hover_zoom": "medium",
+        "stacked_scroll": "always",
+        "underline_active": true,
+        "media_arrows": "desktop",
+        "show_slide_count": true,
+        "media_thumbs": "desktop",
+        "lightbox_thumbnails": true,
+        "thumb_ratio": "1",
+        "thumb_crop": "none",
+        "border_color": "#eeeeee",
+        "bg_color": "#f4f4f4",
+        "enable_media_grouping": true,
+        "media_grouping_option": "Color,Colour,Couleur,Farbe"
+      }
+    },
+    "icons_with_text_8yNjYG": {
+      "type": "icons-with-text",
+      "blocks": {
+        "item_RNjhbX": {
+          "type": "item",
+          "settings": {
+            "icon": "truck",
+            "heading": "Free shipping",
+            "text": "<p>On all orders over $100</p>",
+            "link": ""
+          }
+        },
+        "item_M6WDyn": {
+          "type": "item",
+          "settings": {
+            "icon": "price_tag",
+            "heading": "Special offers",
+            "text": "<p>Regular sales and discounts</p>",
+            "link": ""
+          }
+        },
+        "item_GkUzBU": {
+          "type": "item",
+          "settings": {
+            "icon": "return",
+            "heading": "Easy returns",
+            "text": "<p>Hassle free returns policy</p>",
+            "link": ""
+          }
+        },
+        "item_Ad3a4K": {
+          "type": "item",
+          "settings": {
+            "icon": "chat_bubble",
+            "heading": "Chat facility",
+            "text": "<p>Talk to a real person</p>",
+            "link": ""
+          }
+        }
+      },
+      "block_order": [
+        "item_RNjhbX",
+        "item_M6WDyn",
+        "item_GkUzBU",
+        "item_Ad3a4K"
+      ],
+      "settings": {
+        "heading": "",
+        "heading_align": "text-start",
+        "icon_size": 48,
+        "title_type_scale": "medium",
+        "text_type_scale": "medium",
+        "icon_position": "beside",
+        "mobile_stack": false,
+        "section_height": "medium",
+        "color_scheme": "none",
+        "full_width": true,
+        "dividers": "border-bottom",
+        "prevent_animation": false
+      }
+    },
+    "custom_liquid_PAtp9p": {
+      "type": "custom-liquid",
+      "settings": {
+        "custom_liquid": "{% comment %}\nCustom Liquid Snippet für collapsible Content\n\nDieses Snippet zeigt die folgenden Metafelder nur an, wenn diese einen Inhalt haben:\n- custom.importeur\n- custom.herstellerinformationen\n- custom.eu_verantwortliche_person\n\nSpeichere diesen Code z. B. als \"custom-collapsible-specs.liquid\" in deinem Snippets-Ordner\nund binde ihn in deiner Produktseite mit:\n{% raw %}{% render 'custom-collapsible-specs' %}{% endraw %}\nein.\n{% endcomment %}\n\n<style>\n  /* Grundlegende Styles für collapsible Abschnitte */\n  .collapsible-section {\n    border: 1px solid #ccc;\n    border-radius: 4px;\n    margin-bottom: 20px;\n    overflow: hidden;\n  }\n  .collapsible-section summary {\n    cursor: pointer;\n    padding: 10px 15px;\n    background-color: #f5f5f5;\n    font-weight: bold;\n    outline: none;\n  }\n  .collapsible-section[open] summary {\n    border-bottom: 1px solid #ccc;\n  }\n  .collapsible-section .collapsible-content {\n    padding: 15px;\n    background-color: #fff;\n    line-height: 1.5;\n    color: #333;\n  }\n</style>\n\n<div class=\"product-collapsible\">\n  {% if product.metafields.custom.importeur and product.metafields.custom.importeur.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>Importeur</summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.importeur.value }}\n      </div>\n    </details>\n  {% endif %}\n\n  {% if product.metafields.custom.herstellerinformationen and product.metafields.custom.herstellerinformationen.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>Herstellerinformationen</summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.herstellerinformationen.value }}\n      </div>\n    </details>\n  {% endif %}\n\n  {% if product.metafields.custom.eu_verantwortliche_person and product.metafields.custom.eu_verantwortliche_person.value != blank %}\n    <details class=\"collapsible-section\">\n      <summary>EU Verantwortliche Person</summary>\n      <div class=\"collapsible-content\">\n        {{ product.metafields.custom.eu_verantwortliche_person.value }}\n      </div>\n    </details>\n  {% endif %}\n</div>",
+        "section_height": "default",
+        "full_width": false,
+        "dividers": "none",
+        "prevent_animation": false
+      }
+    },
+    "17200888731a472e47": {
+      "type": "apps",
+      "settings": {
+        "full_width": false
+      }
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "heading": "Das könnte Ihnen auch gefallen",
+        "heading_align": "text-start",
+        "layout": "carousel",
+        "card_size_mobile": "small",
+        "card_size": "small",
+        "products_to_show": 8
+      }
+    }
+  },
+  "order": [
+    "main",
+    "icons_with_text_8yNjYG",
+    "custom_liquid_PAtp9p",
+    "17200888731a472e47",
+    "recommendations"
+  ]
+}

--- a/templates/product.testwe.json
+++ b/templates/product.testwe.json
@@ -1,1 +1,213 @@
-{"sections":{"main":{"type":"main-product","blocks":{"vendor-sku":{"type":"vendor-sku","settings":{"show_vendor":false,"show_sku":true,"show_barcode":false}},"title":{"type":"title","settings":{"show_weight":false}},"inventory_status_Jhajhy":{"type":"inventory-status","settings":{"show_indicator_bar":true,"show_urgency_message":true,"text_very_low":"<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage<\/p>","text_low":"<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage<\/p>","text_normal":"<p>| Lieferzeit 1-3 Tage<\/p>","text_no_stock":"<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.<\/p>","text_no_stock_backordered":"<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.<\/p>"}},"divider_gtUcUd":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"custom_liquid_rBmMbp":{"type":"custom-liquid","disabled":true,"settings":{"custom_liquid":"{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage<\/p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar<\/p>\n{% endif %}"}},"price":{"type":"price","settings":{"show_tax_and_shipping":true}},"divider-0":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"product-labels":{"type":"product-labels","settings":{"show_variant_icon":true}},"divider_fbkn9A":{"type":"divider","disabled":true,"settings":{"show_line":true,"spacing":"mt-8 mb-8"}},"variant-picker":{"type":"variant-picker","settings":{"selector_style":"buttons","enable_dynamic_availability":true,"dynamic_availability_downwards":true,"show_backorder_text":true,"enable_size_chart":false,"size_chart_variant":"Size","size_chart_page":""}},"buy-buttons":{"type":"buy-buttons","settings":{"show_qty_selector":true,"enable_dynamic_checkout":true,"show_pickup_availability":true,"show_gift_card_recipient":false}},"complementary_rx84bf":{"type":"complementary","settings":{"heading":"Passend dazu!","products_to_show":4,"layout":"list"}},"collapsible-content-2":{"type":"collapsible-content","settings":{"heading":"Versand","icon":"truck","text":"<p>Klimafreundlicher kostenloser Versand innerhalb Deutschland.<\/p>","page":"","open":false}},"collapsible_content_3HkYGJ":{"type":"collapsible-content","settings":{"heading":"Rückgabe","icon":"return","text":"<p>30 Tage Rückgaberecht.<\/p>","page":"","open":false}},"description_Nz7fFB":{"type":"description","settings":{"show_as_collapsible_content":true,"icon":"eye","open":false}},"sledge_review_widget_ijMP7p":{"type":"shopify:\/\/apps\/sledge\/blocks\/review-widget\/213c3487-6448-44c0-baa7-868f58d5291d","settings":{"product":"{{product}}","max_width":1180}}},"block_order":["vendor-sku","title","inventory_status_Jhajhy","divider_gtUcUd","custom_liquid_rBmMbp","price","divider-0","product-labels","divider_fbkn9A","variant-picker","buy-buttons","complementary_rx84bf","collapsible-content-2","collapsible_content_3HkYGJ","description_Nz7fFB","sledge_review_widget_ijMP7p"],"custom_css":[".fixed-size-desktop {width: 300px !important; height: 300px !important; object-fit: contain;}"],"settings":{"stick_on_scroll":false,"select_first_variant":true,"sticky_atc_panel":true,"sticky_atc_position":"end","sticky_atc_mobile":true,"media_layout":"slider","media_size":"large","media_ratio":"natural","media_crop":"none","enable_video_looping":false,"enable_zoom":true,"zoom_mode":"hover","enable_lightbox_mobile":false,"hover_zoom":"original","stacked_scroll":"always","underline_active":true,"media_arrows":"never","show_slide_count":false,"media_thumbs":"never","lightbox_thumbnails":false,"thumb_ratio":"natural","thumb_crop":"none","border_color":"#eeeeee","bg_color":"#f4f4f4","enable_media_grouping":true,"media_grouping_option":"Color,Colour,Couleur,Farbe"}},"details":{"type":"product-details","blocks":{"tabs":{"type":"tabs","settings":{"style":"tabs","open_first":false,"show_description":false,"show_reviews":true,"custom_reviews":"","show_specification":true,"spec_metafields":"Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten","spec_right_align":false,"spec_show_empty_metafields":false,"spec_empty_field_text":"-","tab_1_title":"Herstellerinformationen","tab_1_text":"<p><strong>Herstellerinformationen: <\/strong><\/p><p>{{ product.metafields.custom.herstellerinformationen | metafield_tag }}<\/p><p><strong>Importeur: <\/strong><\/p><p>{{ product.metafields.custom.importeur | metafield_tag }}<\/p><p><strong>EU-Verantwortliche Person:<\/strong><\/p><p>{{ product.metafields.custom.eu_verantwortliche_person | metafield_tag }}<\/p><p><\/p>","tab_1_page":"","tab_2_title":"","tab_2_text":"","tab_2_page":"","tab_3_title":"","tab_3_text":"","tab_3_page":""}}},"block_order":["tabs"],"custom_css":[],"settings":{}},"17200888731a472e47":{"type":"apps","settings":{"full_width":false}},"recommendations":{"type":"product-recommendations","settings":{"heading":"Das könnte Ihnen auch gefallen","heading_align":"text-start","layout":"carousel","card_size_mobile":"small","card_size":"small","products_to_show":8}}},"order":["main","details","17200888731a472e47","recommendations"]}
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "vendor-sku": {
+          "type": "vendor-sku",
+          "settings": {
+            "show_vendor": false,
+            "show_sku": true,
+            "show_barcode": false
+          }
+        },
+        "title": {
+          "type": "title",
+          "settings": {
+            "show_weight": false
+          }
+        },
+        "inventory_status_Jhajhy": {
+          "type": "inventory-status",
+          "settings": {
+            "show_indicator_bar": true,
+            "show_urgency_message": true,
+            "text_very_low": "<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage</p>",
+            "text_low": "<p>- Fast ausverkauft! | Lieferzeit 1-3 Tage</p>",
+            "text_normal": "<p>| Lieferzeit 1-3 Tage</p>",
+            "text_no_stock": "<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.</p>",
+            "text_no_stock_backordered": "<p>Der Artikel ist leider nicht vorrätig, aber bald wieder erhältlich.</p>"
+          }
+        },
+        "divider_gtUcUd": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "custom_liquid_rBmMbp": {
+          "type": "custom-liquid",
+          "disabled": true,
+          "settings": {
+            "custom_liquid": "{% assign available = false %}\n{% for variant in product.variants %}\n  {% if variant.available %}\n    {% assign available = true %}\n    {% break %}\n  {% endif %}\n{% endfor %}\n\n{% if available %}\n  <p>Lieferzeit: 1-3 Tage</p>\n{% else %}\n  <p style=\"color: grey;\">Bald wieder lieferbar</p>\n{% endif %}"
+          }
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_tax_and_shipping": true
+          }
+        },
+        "divider-0": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "product-labels": {
+          "type": "product-labels",
+          "settings": {
+            "show_variant_icon": true
+          }
+        },
+        "divider_fbkn9A": {
+          "type": "divider",
+          "disabled": true,
+          "settings": {
+            "show_line": true,
+            "spacing": "mt-8 mb-8"
+          }
+        },
+        "variant-picker": {
+          "type": "variant-picker",
+          "settings": {
+            "selector_style": "buttons",
+            "enable_dynamic_availability": true,
+            "dynamic_availability_downwards": true,
+            "show_backorder_text": true,
+            "enable_size_chart": false,
+            "size_chart_variant": "Size",
+            "size_chart_page": ""
+          }
+        },
+        "buy-buttons": {
+          "type": "buy-buttons",
+          "settings": {
+            "show_qty_selector": true,
+            "enable_dynamic_checkout": true,
+            "show_pickup_availability": true,
+            "show_gift_card_recipient": false
+          }
+        },
+        "complementary_rx84bf": {
+          "type": "complementary",
+          "settings": {
+            "heading": "Passend dazu!",
+            "products_to_show": 4,
+            "layout": "list"
+          }
+        },
+        "collapsible-content-2": {
+          "type": "collapsible-content",
+          "settings": {
+            "heading": "Versand",
+            "icon": "truck",
+            "text": "<p>Klimafreundlicher kostenloser Versand innerhalb Deutschland.</p>",
+            "page": "",
+            "open": false
+          }
+        },
+        "collapsible_content_3HkYGJ": {
+          "type": "collapsible-content",
+          "settings": {
+            "heading": "Rückgabe",
+            "icon": "return",
+            "text": "<p>30 Tage Rückgaberecht.</p>",
+            "page": "",
+            "open": false
+          }
+        },
+        "description_Nz7fFB": {
+          "type": "description",
+          "settings": {
+            "show_as_collapsible_content": true,
+            "icon": "eye",
+            "open": false
+          }
+        },
+        "sledge_review_widget_ijMP7p": {
+          "type": "shopify://apps/sledge/blocks/review-widget/213c3487-6448-44c0-baa7-868f58d5291d",
+          "settings": {
+            "product": "{{product}}",
+            "max_width": 1180
+          }
+        }
+      },
+      "block_order": [
+        "vendor-sku",
+        "title",
+        "inventory_status_Jhajhy",
+        "divider_gtUcUd",
+        "custom_liquid_rBmMbp",
+        "price",
+        "divider-0",
+        "product-labels",
+        "divider_fbkn9A",
+        "variant-picker",
+        "buy-buttons",
+        "complementary_rx84bf",
+        "collapsible-content-2",
+        "collapsible_content_3HkYGJ",
+        "description_Nz7fFB",
+        "sledge_review_widget_ijMP7p"
+      ],
+      "custom_css": [
+        ".fixed-size-desktop {width: 300px !important; height: 300px !important; object-fit: contain;}"
+      ],
+      "settings": {
+        "stick_on_scroll": false,
+        "select_first_variant": true,
+        "sticky_atc_panel": true,
+        "sticky_atc_position": "end",
+        "sticky_atc_mobile": true,
+        "media_layout": "slider",
+        "media_size": "large",
+        "media_ratio": "natural",
+        "media_crop": "none",
+        "enable_video_looping": false,
+        "enable_zoom": true,
+        "zoom_mode": "hover",
+        "enable_lightbox_mobile": false,
+        "hover_zoom": "original",
+        "stacked_scroll": "always",
+        "underline_active": true,
+        "media_arrows": "never",
+        "show_slide_count": false,
+        "media_thumbs": "never",
+        "lightbox_thumbnails": false,
+        "thumb_ratio": "natural",
+        "thumb_crop": "none",
+        "border_color": "#eeeeee",
+        "bg_color": "#f4f4f4",
+        "enable_media_grouping": true,
+        "media_grouping_option": "Color,Colour,Couleur,Farbe"
+      }
+    },
+    "17200888731a472e47": {
+      "type": "apps",
+      "settings": {
+        "full_width": false
+      }
+    },
+    "recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "heading": "Das könnte Ihnen auch gefallen",
+        "heading_align": "text-start",
+        "layout": "carousel",
+        "card_size_mobile": "small",
+        "card_size": "small",
+        "products_to_show": 8
+      }
+    }
+  },
+  "order": [
+    "main",
+    "17200888731a472e47",
+    "recommendations"
+  ]
+}


### PR DESCRIPTION
## Summary
- Render product-details section at bottom of product info card
- Remove standalone product-details section from product templates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `theme-check` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689592e6d9088326a78a9c38d8a4e3ee