### PR TITLE
Move product details into product info card

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -121,7 +121,7 @@
     </div>
 
     <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media,.cc-main-product + .cc-product-details .container"{% endif %}>
+         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
       {%- if section.settings.stick_on_scroll -%}
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
       <sticky-scroll-direction data-min-sticky-size="md">
@@ -682,6 +682,7 @@
             {%- endif -%}
         {%- endcase -%}
       {%- endfor -%}
+      {% section 'product-details' %}
       </div>
 
       {%- if section.settings.stick_on_scroll -%}

--- a/templates/product.json
+++ b/templates/product.json
@@ -134,40 +134,6 @@
         "media_grouping_option": "Color,Colour,Couleur,Farbe"
       }
     },
-    "details": {
-      "type": "product-details",
-      "blocks": {
-        "tabs": {
-          "type": "tabs",
-          "settings": {
-            "style": "tabs",
-            "open_first": false,
-            "show_description": true,
-            "show_reviews": false,
-            "custom_reviews": "",
-            "show_specification": false,
-            "spec_metafields": "Art: custom.art\nVerbindungsart: custom.verbindungsart\nMaterial: custom.material\nKompatibel für: custom.kompatibel_f_r\nBefestigungsart: custom.befestigungsart\nSicherungsart: custom.sicherungsmethode\nLadeart: custom.ladeart\nAkkukapazität: custom.akkukapazit_t\nLadeleistung: custom.ladeleistung\nLieferumfang: custom.lieferumfang\nFarbe: custom.farbe\nLänge: custom.l_nge\nMaße: custom.ma_e\nBesonderheiten: custom.besonderheiten",
-            "spec_right_align": false,
-            "spec_show_empty_metafields": false,
-            "spec_empty_field_text": "-",
-            "tab_1_title": "Herstellerinformationen",
-            "tab_1_text": "<p><strong>Herstellerinformationen: </strong></p><p>{{ product.metafields.custom.herstellerinformationen | metafield_tag }}</p><p><strong>Importeur: </strong></p><p>{{ product.metafields.custom.importeur | metafield_tag }}</p><p><strong>EU-Verantwortliche Person:</strong></p><p>{{ product.metafields.custom.eu_verantwortliche_person | metafield_tag }}</p><p></p>",
-            "tab_1_page": "",
-            "tab_2_title": "",
-            "tab_2_text": "",
-            "tab_2_page": "",
-            "tab_3_title": "",
-            "tab_3_text": "",
-            "tab_3_page": ""
-          }
-        }
-      },
-      "block_order": [
-        "tabs"
-      ],
-      "custom_css": [],
-      "settings": {}
-    },
     "recommendations": {
       "type": "product-recommendations",
       "settings": {
@@ -199,7 +165,6 @@
   },
   "order": [
     "main",
-    "details",
     "recommendations",
     "1743585275ab058f49"
   ]


### PR DESCRIPTION
## Summary
- render product details inside main product info card so tabs appear at bottom
- remove standalone product details section from default product template

## Testing
- `theme-check`

------
https://chatgpt.com/codex/tasks/task_e_689592e6d9088326a78a9c38d8a4e3ee